### PR TITLE
adding test skeleton for better inner loop test.

### DIFF
--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -1,0 +1,31 @@
+import * as core from "@actions/core";
+import * as im from "@actions/exec/lib/interfaces";
+
+import * as linux from "../src/setup-ros-linux";
+import * as osx from "../src/setup-ros-osx";
+import * as windows from "../src/setup-ros-windows";
+import * as utils from "../src/utils";
+
+utils.lib.exec = jest.fn(async (commandLine: string,
+    args?: string[],
+    options?: im.ExecOptions,
+    log_message?: string) => 
+    {
+        const argsAsString = (args || []).join(" ");
+        const message = log_message || `Invoking "${commandLine} ${argsAsString}"`;
+        return core.group(message, async () => {
+            return 0;
+        });
+    });
+
+test('run Windows workflow', async () => {
+    return windows.runWindows();
+})
+
+test('run Linux workflow', async () => {
+    return linux.runLinux();
+})
+
+test('run macOS workflow', async () => {
+    return osx.runOsX();
+})

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -48,7 +48,7 @@ const aptDependencies: string[] = [
  * @returns Promise<number> exit code
  */
 export async function runAptGetInstall(packages: string[]): Promise<number> {
-	return utils.exec("sudo", aptCommandLine.concat(packages));
+	return utils.lib.exec("sudo", aptCommandLine.concat(packages));
 }
 
 /**

--- a/src/package_manager/brew.ts
+++ b/src/package_manager/brew.ts
@@ -26,7 +26,7 @@ const brewDependencies: string[] = [
  * @returns Promise<number> exit code
  */
 export async function runBrew(packages: string[]): Promise<number> {
-	return utils.exec("brew", ["install"].concat(packages));
+	return utils.lib.exec("brew", ["install"].concat(packages));
 }
 
 /**

--- a/src/package_manager/chocolatey.ts
+++ b/src/package_manager/chocolatey.ts
@@ -28,7 +28,7 @@ const ros2ChocolateyPackages: string[] = [
  * @returns Promise<number> exit code
  */
 export async function runChocoInstall(packages: string[]): Promise<number> {
-	return utils.exec("choco", chocoCommandLine.concat(packages));
+	return utils.lib.exec("choco", chocoCommandLine.concat(packages));
 }
 
 /**
@@ -46,8 +46,8 @@ export async function installChocoDependencies(): Promise<number> {
  * @returns Promise<number> exit code
  */
 export async function downloadAndInstallRos2NugetPackages(): Promise<number> {
-	await utils.exec("wget", ["--quiet"].concat(ros2ChocolateyPackagesUrl));
-	return utils.exec(
+	await utils.lib.exec("wget", ["--quiet"].concat(ros2ChocolateyPackagesUrl));
+	return utils.lib.exec(
 		"choco",
 		["install", "-s", ".", "-y"].concat(ros2ChocolateyPackages)
 	);

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -70,9 +70,9 @@ export async function runPython3PipInstall(
 	const sudo_enabled = run_with_sudo === undefined ? true : run_with_sudo;
 	const args = pip3CommandLine.concat(packages);
 	if (sudo_enabled) {
-		return utils.exec("sudo", pip3CommandLine.concat(packages));
+		return utils.lib.exec("sudo", pip3CommandLine.concat(packages));
 	} else {
-		return utils.exec(args[0], args.splice(1));
+		return utils.lib.exec(args[0], args.splice(1));
 	}
 }
 

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -15,8 +15,8 @@ export async function runLinux() {
 	try {
 		await io.which("sudo", true);
 	} catch (err) {
-		await utils.exec("apt-get", ["update"]);
-		await utils.exec("apt-get", [
+		await utils.lib.exec("apt-get", ["update"]);
+		await utils.lib.exec("apt-get", [
 			"install",
 			"--no-install-recommends",
 			"--quiet",
@@ -25,19 +25,19 @@ export async function runLinux() {
 		]);
 	}
 
-	await utils.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
-	await utils.exec("sudo", ["apt-get", "update"]);
+	await utils.lib.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
+	await utils.lib.exec("sudo", ["apt-get", "update"]);
 
 	// Install tools required to configure the worker system.
 	await apt.runAptGetInstall(["curl", "gnupg2", "locales", "lsb-release"]);
 
 	// Select a locale supporting Unicode.
-	await utils.exec("sudo", ["locale-gen", "en_US", "en_US.UTF-8"]);
+	await utils.lib.exec("sudo", ["locale-gen", "en_US", "en_US.UTF-8"]);
 	core.exportVariable("LANG", "en_US.UTF-8");
 
 	// Enforce UTC time for consistency.
-	await utils.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
-	await utils.exec("sudo", [
+	await utils.lib.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
+	await utils.lib.exec("sudo", [
 		"ln",
 		"-sf",
 		"/usr/share/zoneinfo/Etc/UTC",
@@ -47,7 +47,7 @@ export async function runLinux() {
 
 	// OSRF APT repository is necessary, even when building
 	// from source to install colcon, vcs, etc.
-	await utils.exec("sudo", [
+	await utils.lib.exec("sudo", [
 		"apt-key",
 		"adv",
 		"--keyserver",
@@ -55,17 +55,17 @@ export async function runLinux() {
 		"--recv-keys",
 		"C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654"
 	]);
-	await utils.exec("sudo", [
+	await utils.lib.exec("sudo", [
 		"bash",
 		"-c",
 		`echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`
 	]);
-	await utils.exec("sudo", [
+	await utils.lib.exec("sudo", [
 		"bash",
 		"-c",
 		`echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list`
 	]);
-	await utils.exec("sudo", ["apt-get", "update"]);
+	await utils.lib.exec("sudo", ["apt-get", "update"]);
 
 	// Install rosdep and vcs, as well as FastRTPS dependencies, OpenSplice, and RTI Connext.
 	// vcs dependencies (e.g. git), as well as base building packages are not pulled by rosdep, so
@@ -78,7 +78,7 @@ export async function runLinux() {
 	await pip.installPython3Dependencies();
 
 	// Initializes rosdep
-	await utils.exec("sudo", ["rosdep", "init"]);
+	await utils.lib.exec("sudo", ["rosdep", "init"]);
 
 	const requiredRosDistributions = core.getInput("required-ros-distributions");
 	if (requiredRosDistributions) {

--- a/src/setup-ros-osx.ts
+++ b/src/setup-ros-osx.ts
@@ -1,4 +1,4 @@
-import * as exec from "@actions/exec";
+import * as utils from "./utils";
 
 import * as brew from "./package_manager/brew";
 import * as pip from "./package_manager/pip";
@@ -8,17 +8,17 @@ import * as pip from "./package_manager/pip";
  */
 export async function runOsX() {
 	await brew.installBrewDependencies();
-	await exec.exec("sudo", [
+	await utils.lib.exec("sudo", [
 		"bash",
 		"-c",
 		'echo "export OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> ~/.bashrc'
 	]);
-	await exec.exec("sudo", [
+	await utils.lib.exec("sudo", [
 		"bash",
 		"-c",
 		'echo "export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/usr/local/opt/qt" >> ~/.bashrc'
 	]);
-	await exec.exec("sudo", [
+	await utils.lib.exec("sudo", [
 		"bash",
 		"-c",
 		'echo "export PATH=$PATH:/usr/local/opt/qt/bin" >> ~/.bashrc'
@@ -30,5 +30,5 @@ export async function runOsX() {
 	await pip.runPython3PipInstall(["rosdep", "vcstool"]);
 
 	// Initializes rosdep
-	await exec.exec("sudo", ["rosdep", "init"]);
+	await utils.lib.exec("sudo", ["rosdep", "init"]);
 }

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -16,5 +16,5 @@ export async function runWindows() {
 	await pip.installPython3Dependencies(false);
 	await pip.runPython3PipInstall(["rosdep", "vcstool"], false);
 	core.addPath("c:\\hostedtoolcache\\windows\\python\\3.6.8\\x64\\scripts");
-	return utils.exec(`py ${rosdepBin}`, ["init"]);
+	return utils.lib.exec(`py ${rosdepBin}`, ["init"]);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,3 +26,7 @@ export async function exec(
 		return actions_exec.exec(commandLine, args, options);
 	});
 }
+
+export const lib = {
+	exec,
+};


### PR DESCRIPTION
This is motivated by that I'd like to see what commands it is going to generate for the platforms I am interested in. That's helpful since most of the time I can spot the problems for my modification by simply inspecting the command list. For now, the test code doesn't do any extensive validation but just mocks the `exec` and simply outputs the commands to run.