### PR TITLE
Rework the test structure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         node-version: '12.x'
     - run: npm ci
     - run: npm run build
+    - run: npm test
 
     - uses: ./ # Uses an action in the root directory
 

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -18,15 +18,15 @@ describe('basic workflow tests', () => {
     })
 
     it('run Linux workflow', async () => {
-        await expect(linux.runLinux()).resolves.toBeUndefined();
+        await expect(linux.runLinux()).resolves.not.toThrow();
     })
 
     it('run Windows workflow', async () => {
-        await expect(windows.runWindows()).resolves.toBeUndefined();
+        await expect(windows.runWindows()).resolves.not.toThrow();
     })
 
     it('run macOS workflow', async () => {
-        await expect(osx.runOsX()).resolves.toBeUndefined();
+        await expect(osx.runOsX()).resolves.not.toThrow();
     })
 })
 
@@ -45,14 +45,14 @@ describe('required-ros-distributions workflow tests', () => {
     })
 
     it('run Linux workflow', async () => {
-        await expect(linux.runLinux()).resolves.toBeUndefined();
+        await expect(linux.runLinux()).resolves.not.toThrow();
     })
 
     it('run Windows workflow', async () => {
-        await expect(windows.runWindows()).resolves.toBeUndefined();
+        await expect(windows.runWindows()).resolves.not.toThrow();
     })
 
     it('run macOS workflow', async () => {
-        await expect(osx.runOsX()).resolves.toBeUndefined();
+        await expect(osx.runOsX()).resolves.not.toThrow();
     })
 })

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -6,26 +6,97 @@ import * as osx from "../src/setup-ros-osx";
 import * as windows from "../src/setup-ros-windows";
 import * as utils from "../src/utils";
 
-utils.lib.exec = jest.fn(async (commandLine: string,
-    args?: string[],
-    options?: im.ExecOptions,
-    log_message?: string) => 
-    {
-        const argsAsString = (args || []).join(" ");
-        const message = log_message || `Invoking "${commandLine} ${argsAsString}"`;
-        return core.group(message, async () => {
-            return 0;
-        });
-    });
 
-test('run Windows workflow', async () => {
-    return windows.runWindows();
+describe('basic workflow tests', () => {
+    let linesOfExec: string[] = [];
+    beforeAll(() => {
+        jest
+            .spyOn(utils, 'exec')
+            .mockImplementation(async (
+                commandLine: string,
+                args?: string[],
+                options?: im.ExecOptions,
+                log_message?: string) => {
+                    let flatArgs = ''
+                    if (args) {
+                        flatArgs = args.map(i => i).join(' ')
+                    }
+                    linesOfExec.push(`${commandLine} ${flatArgs}`)
+                    return 0;
+                });
+    })
+
+    beforeEach(() => {
+        linesOfExec = [];
+    })
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    })
+
+    it('run Linux workflow', async () => {
+        await linux.runLinux();
+        console.log(linesOfExec);
+    })
+
+    it('run Windows workflow', async () => {
+        await windows.runWindows();
+        console.log(linesOfExec);
+    })
+
+    it('run macOS workflow', async () => {
+        await osx.runOsX();
+        console.log(linesOfExec);
+    })
 })
 
-test('run Linux workflow', async () => {
-    return linux.runLinux();
-})
+describe('required-ros-distributions workflow tests', () => {
+    let linesOfExec: string[] = [];
 
-test('run macOS workflow', async () => {
-    return osx.runOsX();
+    beforeAll(() => {
+        jest
+            .spyOn(utils, 'exec')
+            .mockImplementation(async (
+                commandLine: string,
+                args?: string[],
+                options?: im.ExecOptions,
+                log_message?: string) => {
+                    let flatArgs = ''
+                    if (args) {
+                        flatArgs = args.map(i => i).join(' ')
+                    }
+                    linesOfExec.push(`${commandLine} ${flatArgs}`)
+                    return 0;
+                });
+        jest
+            .spyOn(core, 'getInput')
+            .mockReturnValue('melodic')
+    })
+
+    beforeEach(() => {
+        linesOfExec = [];
+    })
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    })
+
+    it('run Linux workflow', async () => {
+        await linux.runLinux();
+        console.log(linesOfExec);
+        expect(linesOfExec)
+            .toContain('sudo DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes apt-get install --no-install-recommends --quiet --yes ros-melodic-desktop')
+    })
+
+    it('run Windows workflow', async () => {
+        await windows.runWindows();
+        console.log(linesOfExec);
+        expect(linesOfExec)
+            .toContain('choco install --limit-output --yes python --version=3.7.6')
+    })
+
+    it('run macOS workflow', async () => {
+        await osx.runOsX();
+        console.log(linesOfExec);
+    })
 })

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -30,7 +30,7 @@ describe('basic workflow tests', () => {
     })
 })
 
-describe('required-ros-distributions workflow tests', () => {
+describe('required-ros-distributions/melodic workflow tests', () => {
     beforeAll(() => {
         jest
             .spyOn(actions_exec, 'exec')

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -1,33 +1,16 @@
 import * as core from "@actions/core";
-import * as im from "@actions/exec/lib/interfaces";
+import * as actions_exec from "@actions/exec";
 
 import * as linux from "../src/setup-ros-linux";
 import * as osx from "../src/setup-ros-osx";
 import * as windows from "../src/setup-ros-windows";
-import * as utils from "../src/utils";
 
 
 describe('basic workflow tests', () => {
-    let linesOfExec: string[] = [];
     beforeAll(() => {
         jest
-            .spyOn(utils, 'exec')
-            .mockImplementation(async (
-                commandLine: string,
-                args?: string[],
-                options?: im.ExecOptions,
-                log_message?: string) => {
-                    let flatArgs = ''
-                    if (args) {
-                        flatArgs = args.map(i => i).join(' ')
-                    }
-                    linesOfExec.push(`${commandLine} ${flatArgs}`)
-                    return 0;
-                });
-    })
-
-    beforeEach(() => {
-        linesOfExec = [];
+            .spyOn(actions_exec, 'exec')
+            .mockImplementation(jest.fn());
     })
 
     afterAll(() => {
@@ -35,46 +18,26 @@ describe('basic workflow tests', () => {
     })
 
     it('run Linux workflow', async () => {
-        await linux.runLinux();
-        console.log(linesOfExec);
+        await expect(linux.runLinux()).resolves.toBeUndefined();
     })
 
     it('run Windows workflow', async () => {
-        await windows.runWindows();
-        console.log(linesOfExec);
+        await expect(windows.runWindows()).resolves.toBeUndefined();
     })
 
     it('run macOS workflow', async () => {
-        await osx.runOsX();
-        console.log(linesOfExec);
+        await expect(osx.runOsX()).resolves.toBeUndefined();
     })
 })
 
 describe('required-ros-distributions workflow tests', () => {
-    let linesOfExec: string[] = [];
-
     beforeAll(() => {
         jest
-            .spyOn(utils, 'exec')
-            .mockImplementation(async (
-                commandLine: string,
-                args?: string[],
-                options?: im.ExecOptions,
-                log_message?: string) => {
-                    let flatArgs = ''
-                    if (args) {
-                        flatArgs = args.map(i => i).join(' ')
-                    }
-                    linesOfExec.push(`${commandLine} ${flatArgs}`)
-                    return 0;
-                });
+            .spyOn(actions_exec, 'exec')
+            .mockImplementation(jest.fn());
         jest
             .spyOn(core, 'getInput')
-            .mockReturnValue('melodic')
-    })
-
-    beforeEach(() => {
-        linesOfExec = [];
+            .mockReturnValue('melodic');
     })
 
     afterAll(() => {
@@ -82,21 +45,14 @@ describe('required-ros-distributions workflow tests', () => {
     })
 
     it('run Linux workflow', async () => {
-        await linux.runLinux();
-        console.log(linesOfExec);
-        expect(linesOfExec)
-            .toContain('sudo DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes apt-get install --no-install-recommends --quiet --yes ros-melodic-desktop')
+        await expect(linux.runLinux()).resolves.toBeUndefined();
     })
 
     it('run Windows workflow', async () => {
-        await windows.runWindows();
-        console.log(linesOfExec);
-        expect(linesOfExec)
-            .toContain('choco install --limit-output --yes python --version=3.7.6')
+        await expect(windows.runWindows()).resolves.toBeUndefined();
     })
 
     it('run macOS workflow', async () => {
-        await osx.runOsX();
-        console.log(linesOfExec);
+        await expect(osx.runOsX()).resolves.toBeUndefined();
     })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -1758,7 +1758,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils = __importStar(__webpack_require__(163));
 const chocoCommandLine = ["install", "--limit-output", "--yes"];
-const chocoDependencies = ["patch", "cppcheck", "python", "wget"];
+const chocoDependencies = ["patch", "cppcheck", "wget"];
 const chocoPythonRuntime = ["python", "--version=3.7.6"];
 const ros2ChocolateyPackagesUrl = [
     "https://github.com/ros2/choco-packages/releases/download/2019-10-24/asio.1.12.1.nupkg",

--- a/dist/index.js
+++ b/dist/index.js
@@ -1758,8 +1758,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils = __importStar(__webpack_require__(163));
 const chocoCommandLine = ["install", "--limit-output", "--yes"];
-const chocoDependencies = ["patch", "cppcheck", "wget"];
-const chocoPythonRuntime = ["python", "--version=3.7.6"];
+const chocoDependencies = ["patch", "cppcheck", "python", "wget"];
 const ros2ChocolateyPackagesUrl = [
     "https://github.com/ros2/choco-packages/releases/download/2019-10-24/asio.1.12.1.nupkg",
     "https://github.com/ros2/choco-packages/releases/download/2019-10-24/cunit.2.1.3.nupkg",
@@ -1795,7 +1794,6 @@ exports.runChocoInstall = runChocoInstall;
  */
 function installChocoDependencies() {
     return __awaiter(this, void 0, void 0, function* () {
-        yield runChocoInstall(chocoPythonRuntime);
         return runChocoInstall(chocoDependencies);
     });
 }

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -48,7 +48,7 @@ const aptDependencies: string[] = [
  * @returns Promise<number> exit code
  */
 export async function runAptGetInstall(packages: string[]): Promise<number> {
-	return utils.lib.exec("sudo", aptCommandLine.concat(packages));
+	return utils.exec("sudo", aptCommandLine.concat(packages));
 }
 
 /**

--- a/src/package_manager/brew.ts
+++ b/src/package_manager/brew.ts
@@ -26,7 +26,7 @@ const brewDependencies: string[] = [
  * @returns Promise<number> exit code
  */
 export async function runBrew(packages: string[]): Promise<number> {
-	return utils.lib.exec("brew", ["install"].concat(packages));
+	return utils.exec("brew", ["install"].concat(packages));
 }
 
 /**

--- a/src/package_manager/chocolatey.ts
+++ b/src/package_manager/chocolatey.ts
@@ -4,6 +4,8 @@ const chocoCommandLine: string[] = ["install", "--limit-output", "--yes"];
 
 const chocoDependencies: string[] = ["patch", "cppcheck", "python", "wget"];
 
+const chocoPythonRuntime: string[] = ["python", "--version=3.7.6"]
+
 const ros2ChocolateyPackagesUrl: string[] = [
 	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/asio.1.12.1.nupkg",
 	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/cunit.2.1.3.nupkg",
@@ -28,7 +30,7 @@ const ros2ChocolateyPackages: string[] = [
  * @returns Promise<number> exit code
  */
 export async function runChocoInstall(packages: string[]): Promise<number> {
-	return utils.lib.exec("choco", chocoCommandLine.concat(packages));
+	return utils.exec("choco", chocoCommandLine.concat(packages));
 }
 
 /**
@@ -37,6 +39,7 @@ export async function runChocoInstall(packages: string[]): Promise<number> {
  * @returns Promise<number> exit code
  */
 export async function installChocoDependencies(): Promise<number> {
+	await runChocoInstall(chocoPythonRuntime);
 	return runChocoInstall(chocoDependencies);
 }
 
@@ -46,8 +49,8 @@ export async function installChocoDependencies(): Promise<number> {
  * @returns Promise<number> exit code
  */
 export async function downloadAndInstallRos2NugetPackages(): Promise<number> {
-	await utils.lib.exec("wget", ["--quiet"].concat(ros2ChocolateyPackagesUrl));
-	return utils.lib.exec(
+	await utils.exec("wget", ["--quiet"].concat(ros2ChocolateyPackagesUrl));
+	return utils.exec(
 		"choco",
 		["install", "-s", ".", "-y"].concat(ros2ChocolateyPackages)
 	);

--- a/src/package_manager/chocolatey.ts
+++ b/src/package_manager/chocolatey.ts
@@ -2,9 +2,7 @@ import * as utils from "../utils";
 
 const chocoCommandLine: string[] = ["install", "--limit-output", "--yes"];
 
-const chocoDependencies: string[] = ["patch", "cppcheck", "wget"];
-
-const chocoPythonRuntime: string[] = ["python", "--version=3.7.6"];
+const chocoDependencies: string[] = ["patch", "cppcheck", "python", "wget"];
 
 const ros2ChocolateyPackagesUrl: string[] = [
 	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/asio.1.12.1.nupkg",
@@ -39,7 +37,6 @@ export async function runChocoInstall(packages: string[]): Promise<number> {
  * @returns Promise<number> exit code
  */
 export async function installChocoDependencies(): Promise<number> {
-	await runChocoInstall(chocoPythonRuntime);
 	return runChocoInstall(chocoDependencies);
 }
 

--- a/src/package_manager/chocolatey.ts
+++ b/src/package_manager/chocolatey.ts
@@ -2,9 +2,9 @@ import * as utils from "../utils";
 
 const chocoCommandLine: string[] = ["install", "--limit-output", "--yes"];
 
-const chocoDependencies: string[] = ["patch", "cppcheck", "python", "wget"];
+const chocoDependencies: string[] = ["patch", "cppcheck", "wget"];
 
-const chocoPythonRuntime: string[] = ["python", "--version=3.7.6"]
+const chocoPythonRuntime: string[] = ["python", "--version=3.7.6"];
 
 const ros2ChocolateyPackagesUrl: string[] = [
 	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/asio.1.12.1.nupkg",

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -70,9 +70,9 @@ export async function runPython3PipInstall(
 	const sudo_enabled = run_with_sudo === undefined ? true : run_with_sudo;
 	const args = pip3CommandLine.concat(packages);
 	if (sudo_enabled) {
-		return utils.lib.exec("sudo", pip3CommandLine.concat(packages));
+		return utils.exec("sudo", pip3CommandLine.concat(packages));
 	} else {
-		return utils.lib.exec(args[0], args.splice(1));
+		return utils.exec(args[0], args.splice(1));
 	}
 }
 

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -15,8 +15,8 @@ export async function runLinux() {
 	try {
 		await io.which("sudo", true);
 	} catch (err) {
-		await utils.lib.exec("apt-get", ["update"]);
-		await utils.lib.exec("apt-get", [
+		await utils.exec("apt-get", ["update"]);
+		await utils.exec("apt-get", [
 			"install",
 			"--no-install-recommends",
 			"--quiet",
@@ -25,19 +25,19 @@ export async function runLinux() {
 		]);
 	}
 
-	await utils.lib.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
-	await utils.lib.exec("sudo", ["apt-get", "update"]);
+	await utils.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
+	await utils.exec("sudo", ["apt-get", "update"]);
 
 	// Install tools required to configure the worker system.
 	await apt.runAptGetInstall(["curl", "gnupg2", "locales", "lsb-release"]);
 
 	// Select a locale supporting Unicode.
-	await utils.lib.exec("sudo", ["locale-gen", "en_US", "en_US.UTF-8"]);
+	await utils.exec("sudo", ["locale-gen", "en_US", "en_US.UTF-8"]);
 	core.exportVariable("LANG", "en_US.UTF-8");
 
 	// Enforce UTC time for consistency.
-	await utils.lib.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
-	await utils.lib.exec("sudo", [
+	await utils.exec("sudo", ["bash", "-c", "echo 'Etc/UTC' > /etc/timezone"]);
+	await utils.exec("sudo", [
 		"ln",
 		"-sf",
 		"/usr/share/zoneinfo/Etc/UTC",
@@ -47,7 +47,7 @@ export async function runLinux() {
 
 	// OSRF APT repository is necessary, even when building
 	// from source to install colcon, vcs, etc.
-	await utils.lib.exec("sudo", [
+	await utils.exec("sudo", [
 		"apt-key",
 		"adv",
 		"--keyserver",
@@ -55,17 +55,17 @@ export async function runLinux() {
 		"--recv-keys",
 		"C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654"
 	]);
-	await utils.lib.exec("sudo", [
+	await utils.exec("sudo", [
 		"bash",
 		"-c",
 		`echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`
 	]);
-	await utils.lib.exec("sudo", [
+	await utils.exec("sudo", [
 		"bash",
 		"-c",
 		`echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list`
 	]);
-	await utils.lib.exec("sudo", ["apt-get", "update"]);
+	await utils.exec("sudo", ["apt-get", "update"]);
 
 	// Install rosdep and vcs, as well as FastRTPS dependencies, OpenSplice, and RTI Connext.
 	// vcs dependencies (e.g. git), as well as base building packages are not pulled by rosdep, so
@@ -78,7 +78,7 @@ export async function runLinux() {
 	await pip.installPython3Dependencies();
 
 	// Initializes rosdep
-	await utils.lib.exec("sudo", ["rosdep", "init"]);
+	await utils.exec("sudo", ["rosdep", "init"]);
 
 	const requiredRosDistributions = core.getInput("required-ros-distributions");
 	if (requiredRosDistributions) {

--- a/src/setup-ros-osx.ts
+++ b/src/setup-ros-osx.ts
@@ -8,17 +8,17 @@ import * as pip from "./package_manager/pip";
  */
 export async function runOsX() {
 	await brew.installBrewDependencies();
-	await utils.lib.exec("sudo", [
+	await utils.exec("sudo", [
 		"bash",
 		"-c",
 		'echo "export OPENSSL_ROOT_DIR=$(brew --prefix openssl)" >> ~/.bashrc'
 	]);
-	await utils.lib.exec("sudo", [
+	await utils.exec("sudo", [
 		"bash",
 		"-c",
 		'echo "export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/usr/local/opt/qt" >> ~/.bashrc'
 	]);
-	await utils.lib.exec("sudo", [
+	await utils.exec("sudo", [
 		"bash",
 		"-c",
 		'echo "export PATH=$PATH:/usr/local/opt/qt/bin" >> ~/.bashrc'
@@ -30,5 +30,5 @@ export async function runOsX() {
 	await pip.runPython3PipInstall(["rosdep", "vcstool"]);
 
 	// Initializes rosdep
-	await utils.lib.exec("sudo", ["rosdep", "init"]);
+	await utils.exec("sudo", ["rosdep", "init"]);
 }

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -16,5 +16,5 @@ export async function runWindows() {
 	await pip.installPython3Dependencies(false);
 	await pip.runPython3PipInstall(["rosdep", "vcstool"], false);
 	core.addPath("c:\\hostedtoolcache\\windows\\python\\3.6.8\\x64\\scripts");
-	return utils.lib.exec(`py ${rosdepBin}`, ["init"]);
+	return utils.exec(`py ${rosdepBin}`, ["init"]);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,3 @@ export async function exec(
 		return actions_exec.exec(commandLine, args, options);
 	});
 }
-
-export const lib = {
-	exec,
-};


### PR DESCRIPTION
* Rework the test code to use `jest.spyOn` so we can get rid of the shim in `utils`.
* ~Sync the Windows Python version to `3.7.6` with the one used in [ros2/ci](https://github.com/ros2/ci/). This is motivated by [this](https://github.com/ros2/ros2_documentation/pull/418) because mismatched version might cause unexpected results.~

Signed-off-by: seanyen <seanyen@microsoft.com>