### PR TITLE
[Windows] Enable `required-ros-distributions` installations.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ on:
       # to whitelist those branches for CI run here.
       # See also https://greenkeeper.io/faq#no-initial-pr
       - 'greenkeeper**'
-      - 'seanyen**'
   schedule:
     # Run the CI automatically every hour to look for flakyness.
     - cron:  '0 * * * *'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,3 +152,27 @@ jobs:
         required-ros-distributions: eloquent
     - run: test -f /opt/ros/eloquent/setup.sh
       name: "Check that eloquent setup.sh has been installed."
+
+  # ROS Eloquent Elusor (Windows)
+  test_eloquent_windows:
+    name: "ROS Eloquent Elusor (Windows)"
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - run: npm ci
+    - run: npm run build
+
+    - uses: ./ # Uses an action in the root directory
+      with:
+        required-ros-distributions: eloquent
+    - run: if not exist c:\\dev\\eloquent\\ros2-windows\\local_setup.bat exit 1
+      name: "Check that eloquent local_setup.bat has been installed."
+      shell: cmd
+    - run: |
+        call c:\\dev\\eloquent\\ros2-windows\\local_setup.bat
+        ros2 pkg list
+      name: "List installed ROS 2 packages."
+      shell: cmd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on:
       # to whitelist those branches for CI run here.
       # See also https://greenkeeper.io/faq#no-initial-pr
       - 'greenkeeper**'
+      - 'seanyen**'
   schedule:
     # Run the CI automatically every hour to look for flakyness.
     - cron:  '0 * * * *'
@@ -60,6 +61,31 @@ jobs:
     - run: test -f /opt/ros/melodic/setup.sh
       name: "Check that melodic setup.sh has been installed."
 
+  test_binary_install_windows:
+    name: "ROS 2 Binary Install Test Suite (Windows only)"
+    runs-on: windows-latest
+    strategy:
+      matrix:
+          rosdistro: [dashing, eloquent]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - run: npm ci
+    - run: npm run build
+
+    - uses: ./ # Uses an action in the root directory
+      with:
+        required-ros-distributions: ${{ matrix.rosdistro }}
+    - env:
+        ROSDISTRO: ${{ matrix.rosdistro }}
+      run: |
+        if not exist c:\\dev\\%ROSDISTRO%\\ros2-windows\\local_setup.bat exit 1
+        call c:\\dev\\%ROSDISTRO%\\ros2-windows\\local_setup.bat
+        ros2 pkg list
+      name: "Check that ${{ matrix.rosdistro }} local_setup.bat has been installed."
+      shell: cmd
 
   # ROS distributions which did not reach end-of-life:
   # Kinetic Kame (May 2016 - May 2021)
@@ -152,27 +178,3 @@ jobs:
         required-ros-distributions: eloquent
     - run: test -f /opt/ros/eloquent/setup.sh
       name: "Check that eloquent setup.sh has been installed."
-
-  # ROS Eloquent Elusor (Windows)
-  test_eloquent_windows:
-    name: "ROS Eloquent Elusor (Windows)"
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-    - run: npm ci
-    - run: npm run build
-
-    - uses: ./ # Uses an action in the root directory
-      with:
-        required-ros-distributions: eloquent
-    - run: if not exist c:\\dev\\eloquent\\ros2-windows\\local_setup.bat exit 1
-      name: "Check that eloquent local_setup.bat has been installed."
-      shell: cmd
-    - run: |
-        call c:\\dev\\eloquent\\ros2-windows\\local_setup.bat
-        ros2 pkg list
-      name: "List installed ROS 2 packages."
-      shell: cmd

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+
+# Visual Studio Code files
+.vscode/

--- a/dist/index.js
+++ b/dist/index.js
@@ -1446,15 +1446,15 @@ const core = __importStar(__webpack_require__(470));
 const chocolatey = __importStar(__webpack_require__(510));
 const pip = __importStar(__webpack_require__(230));
 const utils = __importStar(__webpack_require__(163));
-const python37 = "C:\\hostedtoolcache\\windows\\Python\\3.7.6\\x64";
+const python37 = "c:\\hostedtoolcache\\windows\\Python\\3.7.6\\x64";
 const binaryReleases = {
     "dashing": "https://github.com/ros2/ros2/releases/download/release-dashing-20191213/ros2-dashing-20191213-windows-amd64.zip",
     "eloquent": "https://github.com/ros2/ros2/releases/download/release-eloquent-20200124/ros2-eloquent-20200124-windows-release-amd64.zip"
 };
 const pip3Packages = [
-    "numpy",
+    "lxml",
     "netifaces",
-    "lxml"
+    "numpy",
 ];
 /**
  * Install ROS 2 build tools.
@@ -1462,15 +1462,15 @@ const pip3Packages = [
 function prepareRos2BuildEnvironment() {
     return __awaiter(this, void 0, void 0, function* () {
         yield utils.exec(`cmd /c mklink /d c:\\python37 ${python37}`);
-        core.exportVariable("PYTHONHOME", "c:\\Python37");
-        core.addPath("c:\\Python37");
-        core.addPath("c:\\Python37\\Scripts");
+        core.exportVariable("PYTHONHOME", "c:\\python37");
+        core.addPath("c:\\python37");
+        core.addPath("c:\\python37\\scripts");
         yield chocolatey.installChocoDependencies();
         yield chocolatey.downloadAndInstallRos2NugetPackages();
         yield pip.installPython3Dependencies(false);
         yield pip.runPython3PipInstall(pip3Packages, false);
         yield pip.runPython3PipInstall(["rosdep", "vcstool"], false);
-        return utils.exec(`python c:\\Python37\\Scripts\\rosdep`, ["init"]);
+        return utils.exec(`python c:\\python37\\scripts\\rosdep`, ["init"]);
     });
 }
 /**

--- a/src/package_manager/chocolatey.ts
+++ b/src/package_manager/chocolatey.ts
@@ -2,7 +2,7 @@ import * as utils from "../utils";
 
 const chocoCommandLine: string[] = ["install", "--limit-output", "--yes"];
 
-const chocoDependencies: string[] = ["patch", "cppcheck", "python", "wget"];
+const chocoDependencies: string[] = ["patch", "cppcheck", "wget", "7zip"];
 
 const ros2ChocolateyPackagesUrl: string[] = [
 	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/asio.1.12.1.nupkg",

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -80,13 +80,7 @@ export async function runLinux() {
 	// Initializes rosdep
 	await utils.exec("sudo", ["rosdep", "init"]);
 
-	const requiredRosDistributions = core.getInput("required-ros-distributions");
-	if (requiredRosDistributions) {
-		const requiredRosDistributionsList = requiredRosDistributions.split(
-			RegExp("\\s")
-		);
-		for (let rosDistro of requiredRosDistributionsList) {
-			await apt.runAptGetInstall([`ros-${rosDistro}-desktop`]);
-		}
+	for (let rosDistro of utils.getRequiredRosDistributions()) {
+		await apt.runAptGetInstall([`ros-${rosDistro}-desktop`]);
 	}
 }

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -5,7 +5,7 @@ import * as pip from "./package_manager/pip";
 import * as utils from "./utils";
 
 const python37: string =
-	"C:\\hostedtoolcache\\windows\\Python\\3.7.6\\x64";
+	"c:\\hostedtoolcache\\windows\\Python\\3.7.6\\x64";
 
 const binaryReleases: { [index: string]: string; } =
 	{
@@ -14,9 +14,9 @@ const binaryReleases: { [index: string]: string; } =
 	};
 
 const pip3Packages: string[] = [
-	"numpy",
+	"lxml",
 	"netifaces",
-	"lxml"
+	"numpy",
 ];
 
 /**
@@ -24,15 +24,15 @@ const pip3Packages: string[] = [
  */
 async function prepareRos2BuildEnvironment() {
 	await utils.exec(`cmd /c mklink /d c:\\python37 ${python37}`);
-	core.exportVariable("PYTHONHOME", "c:\\Python37");
-	core.addPath("c:\\Python37");
-	core.addPath("c:\\Python37\\Scripts");
+	core.exportVariable("PYTHONHOME", "c:\\python37");
+	core.addPath("c:\\python37");
+	core.addPath("c:\\python37\\scripts");
 	await chocolatey.installChocoDependencies();
 	await chocolatey.downloadAndInstallRos2NugetPackages();
 	await pip.installPython3Dependencies(false);
 	await pip.runPython3PipInstall(pip3Packages, false);
 	await pip.runPython3PipInstall(["rosdep", "vcstool"], false);
-	return utils.exec(`python c:\\Python37\\Scripts\\rosdep`, ["init"]);
+	return utils.exec(`python c:\\python37\\scripts\\rosdep`, ["init"]);
 }
 
 /**

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -4,17 +4,54 @@ import * as chocolatey from "./package_manager/chocolatey";
 import * as pip from "./package_manager/pip";
 import * as utils from "./utils";
 
-const rosdepBin: string =
-	"c:\\hostedtoolcache\\windows\\python\\3.6.8\\x64\\scripts\\rosdep";
+const python37: string =
+	"C:\\hostedtoolcache\\windows\\Python\\3.7.6\\x64";
+
+const binaryReleases: { [index: string]: string; } =
+	{
+		"dashing": "https://github.com/ros2/ros2/releases/download/release-dashing-20191213/ros2-dashing-20191213-windows-amd64.zip",
+		"eloquent": "https://github.com/ros2/ros2/releases/download/release-eloquent-20200124/ros2-eloquent-20200124-windows-release-amd64.zip"
+	};
+
+const pip3Packages: string[] = [
+	"numpy",
+	"netifaces",
+	"lxml"
+];
 
 /**
- * Install ROS 2 on a Windows worker.
+ * Install ROS 2 build tools.
  */
-export async function runWindows() {
+async function prepareRos2BuildEnvironment() {
+	await utils.exec(`cmd /c mklink /d c:\\python37 ${python37}`);
+	core.exportVariable("PYTHONHOME", "c:\\Python37");
+	core.addPath("c:\\Python37");
+	core.addPath("c:\\Python37\\Scripts");
 	await chocolatey.installChocoDependencies();
 	await chocolatey.downloadAndInstallRos2NugetPackages();
 	await pip.installPython3Dependencies(false);
+	await pip.runPython3PipInstall(pip3Packages, false);
 	await pip.runPython3PipInstall(["rosdep", "vcstool"], false);
-	core.addPath("c:\\hostedtoolcache\\windows\\python\\3.6.8\\x64\\scripts");
-	return utils.exec(`py ${rosdepBin}`, ["init"]);
+	return utils.exec(`python c:\\Python37\\Scripts\\rosdep`, ["init"]);
+}
+
+/**
+ * Install ROS 2 binary releases.
+ */
+async function prepareRos2BinaryReleases() {
+	for (let rosDistro of utils.getRequiredRosDistributions()) {
+		if (rosDistro in binaryReleases)
+		{
+			await utils.exec("wget", ["--quiet", binaryReleases[rosDistro], "-O", `${rosDistro}.zip`]);
+			await utils.exec("7z", ["x", `${rosDistro}.zip`, "-y", `-oc:\\dev\\${rosDistro}`])
+		}
+	}
+}
+
+/**
+ * Install build environment on a Windows worker.
+ */
+export async function runWindows() {
+	await prepareRos2BuildEnvironment();
+	return prepareRos2BinaryReleases();
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,3 +26,14 @@ export async function exec(
 		return actions_exec.exec(commandLine, args, options);
 	});
 }
+
+export function getRequiredRosDistributions(): string[] {
+	let requiredRosDistributionsList: string[] = [];
+	const requiredRosDistributions = core.getInput("required-ros-distributions");
+	if (requiredRosDistributions) {
+		requiredRosDistributionsList = requiredRosDistributions.split(
+			RegExp("\\s")
+		);
+	}
+	return requiredRosDistributionsList;
+}


### PR DESCRIPTION
* Keep the Python rumtime in sync (e.g., using `Python 3.7` and installing it under `c:\Python37`) with the one documented [here](https://index.ros.org/doc/ros2/Installation/Eloquent/Windows-Install-Binary/).
* Add additional required PyPi modules. (e.g., numpy, netifaces, lxml).
* Enabling `required-ros-distributions` installations, and deploy the ROS 2 from the official [releases](https://github.com/ros2/ros2/releases).