### PR TITLE
Install catkin_pkg using apt; remove duplicate lark_parser

### DIFF
--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -20,7 +20,7 @@ const aptDependencies: string[] = [
 	"lcov",
 	"libc++-dev",
 	"libc++abi-dev",
-	"python3-lark-parser",
+	"python3-catkin-pkg-modules",
 	"python3-pip",
 	"python3-rosdep",
 	"python3-vcstool",

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -2,7 +2,6 @@ import * as utils from "../utils";
 
 const pip3Packages: string[] = [
 	"argcomplete",
-	"catkin_pkg",
 	"colcon-bash==0.4.1",
 	"colcon-cd==0.1.1",
 	"colcon-cmake==0.2.16",


### PR DESCRIPTION
Changing `catkin-pkg` installation from `pip` to `apt` as per discussion in https://github.com/ros-tooling/setup-ros/issues/50.

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>