### PR TITLE
Add python3-rosinstall-generator from apt

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1069,6 +1069,7 @@ const aptDependencies = [
     "python3-catkin-pkg-modules",
     "python3-pip",
     "python3-rosdep",
+    "python3-rosinstall-generator",
     "python3-vcstool",
     "wget",
     // FastRTPS dependencies

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -23,6 +23,7 @@ const aptDependencies: string[] = [
 	"python3-catkin-pkg-modules",
 	"python3-pip",
 	"python3-rosdep",
+	"python3-rosinstall-generator",
 	"python3-vcstool",
 	"wget",
 	// FastRTPS dependencies


### PR DESCRIPTION
Install `python3-rosinstall-generator` in case a user wants to use it as part of their workflow.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>