### PR TITLE
Remove inexistent `source` option for action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,6 @@ inputs:
         - melodic
         - dashing
         - eloquent
-        - source
 
         Multiple values can be passed using a whitespace delimited list
         "melodic dashing".


### PR DESCRIPTION
This was added mistakenly.

Fix #120