### PR TITLE
Use python-rosdep 

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1068,7 +1068,6 @@ const aptDependencies = [
     "libc++abi-dev",
     "python3-catkin-pkg-modules",
     "python3-pip",
-    "python3-rosinstall-generator",
     "python3-vcstool",
     "wget",
     // FastRTPS dependencies

--- a/dist/index.js
+++ b/dist/index.js
@@ -1068,7 +1068,6 @@ const aptDependencies = [
     "libc++abi-dev",
     "python3-catkin-pkg-modules",
     "python3-pip",
-    "python3-rosdep",
     "python3-rosinstall-generator",
     "python3-vcstool",
     "wget",
@@ -1078,7 +1077,8 @@ const aptDependencies = [
     // OpenSplice
     "libopensplice69",
     // RTI Connext - required to ensure the installation in non-blocking
-    "rti-connext-dds-5.3.1"
+    "rti-connext-dds-5.3.1",
+    "python-rosdep"
 ];
 /**
  * Run apt-get install on list of specified packages.

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -22,7 +22,6 @@ const aptDependencies: string[] = [
 	"libc++abi-dev",
 	"python3-catkin-pkg-modules",
 	"python3-pip",
-	"python3-rosdep",
 	"python3-rosinstall-generator",
 	"python3-vcstool",
 	"wget",
@@ -32,7 +31,8 @@ const aptDependencies: string[] = [
 	// OpenSplice
 	"libopensplice69",
 	// RTI Connext - required to ensure the installation in non-blocking
-	"rti-connext-dds-5.3.1"
+	"rti-connext-dds-5.3.1",
+	"python-rosdep"
 ];
 
 /**

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -22,7 +22,6 @@ const aptDependencies: string[] = [
 	"libc++abi-dev",
 	"python3-catkin-pkg-modules",
 	"python3-pip",
-	"python3-rosinstall-generator",
 	"python3-vcstool",
 	"wget",
 	// FastRTPS dependencies


### PR DESCRIPTION
Instead of using `python3-rosdep`, use `python-rosdep`

Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>