### PR TITLE
Invoke rosdep directly on Windows

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1468,7 +1468,7 @@ function prepareRos2BuildEnvironment() {
         yield pip.installPython3Dependencies(false);
         yield pip.runPython3PipInstall(pip3Packages, false);
         yield pip.runPython3PipInstall(["rosdep", "vcstool"], false);
-        return utils.exec(`python c:\\python37\\scripts\\rosdep`, ["init"]);
+        return utils.exec(`rosdep`, ["init"]);
     });
 }
 /**

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -29,7 +29,7 @@ async function prepareRos2BuildEnvironment() {
 	await pip.installPython3Dependencies(false);
 	await pip.runPython3PipInstall(pip3Packages, false);
 	await pip.runPython3PipInstall(["rosdep", "vcstool"], false);
-	return utils.exec(`python c:\\python37\\scripts\\rosdep`, ["init"]);
+	return utils.exec(`rosdep`, ["init"]);
 }
 
 /**


### PR DESCRIPTION
`rosdep >= 0.19.0` can now be invoked directly as it registers
a console_scripts.

https://github.com/ros-infrastructure/rosdep/issues/754