### PR TITLE
Better python3 setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7259,11 +7259,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
-    "npm-ci": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/npm-ci/-/npm-ci-0.0.2.tgz",
-      "integrity": "sha1-n2t2IMKFeAL7baJoEGnkCinjEHI="
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -54,7 +54,7 @@ const pip3Packages: string[] = [
 	"wheel",
 ];
 
-const pip3CommandLine: string[] = ["pip3", "install", "--upgrade"];
+const pip3CommandLine: string[] = ["python3", "-m", "pip", "install", "--upgrade"];
 
 /**
  * Run Python3 pip install on a list of specified packages.

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -4,8 +4,6 @@ import * as chocolatey from "./package_manager/chocolatey";
 import * as pip from "./package_manager/pip";
 import * as utils from "./utils";
 
-const python37: string = "c:\\hostedtoolcache\\windows\\Python\\3.7.6\\x64";
-
 const binaryReleases: { [index: string]: string } = {
 	dashing:
 		"https://github.com/ros2/ros2/releases/download/release-dashing-20191213/ros2-dashing-20191213-windows-amd64.zip",
@@ -19,10 +17,15 @@ const pip3Packages: string[] = ["lxml", "netifaces"];
  * Install ROS 2 build tools.
  */
 async function prepareRos2BuildEnvironment() {
-	await utils.exec(`cmd /c mklink /d c:\\python37 ${python37}`);
-	core.exportVariable("PYTHONHOME", "c:\\python37");
-	core.addPath("c:\\python37");
-	core.addPath("c:\\python37\\scripts");
+	let python_scripts='';
+	await utils.exec(`python3`,
+	 [`-c`, `import sysconfig; print(sysconfig.get_path('scripts'))`],
+	{
+		listeners: {
+			stdout: (data: Buffer) => { python_scripts += data.toString(); }
+		}
+	});
+	core.addPath(python_scripts.trim());
 	core.addPath("c:\\program files\\cppcheck");
 	await chocolatey.installChocoDependencies();
 	await chocolatey.downloadAndInstallRos2NugetPackages();


### PR DESCRIPTION
1. Use python3 -m pip to ensure that whatever python3 is the default interpreter, we use its pip as per https://docs.python.org/3/installing/index.html#work-with-multiple-versions-of-python-installed-in-parallel
2. On Windows, use whatever the current python3 instead of assuming a python version.

Fixes #156