### PR TITLE
Use python3 -m pip instead of pip3

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1728,7 +1728,7 @@ const pip3Packages = [
     "setuptools",
     "wheel",
 ];
-const pip3CommandLine = ["pip3", "install", "--upgrade"];
+const pip3CommandLine = ["python3", "-m", "pip", "install", "--upgrade"];
 /**
  * Run Python3 pip install on a list of specified packages.
  *

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -54,7 +54,7 @@ const pip3Packages: string[] = [
 	"wheel",
 ];
 
-const pip3CommandLine: string[] = ["pip3", "install", "--upgrade"];
+const pip3CommandLine: string[] = ["python3", "-m", "pip", "install", "--upgrade"];
 
 /**
  * Run Python3 pip install on a list of specified packages.


### PR DESCRIPTION
This is recommended with parallel python installations as per: https://docs.python.org/3/installing/index.html#work-with-multiple-versions-of-python-installed-in-parallel

Signed-off-by: Dan Rose <dan@digilabs.io>
