### PR TITLE
Better CloudWatch handling

### DIFF
--- a/.github/workflows/repo-activity.yaml
+++ b/.github/workflows/repo-activity.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   repo_activity:
+    if: ${{ ! github.event.repository.fork }}
     runs-on: ubuntu-latest
     container:
       image: ubuntu:bionic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,13 +174,10 @@ jobs:
       - test_environment_linux
       - test_multiple_ros_installations
       - test_ros_binary_install_ubuntu
-    if: always() # run even if the dependent jobs have failed to log failures
-    # Allow build reports to fail on pull requests.
-    # When a contribution is made on a fork, the secrets will not be available,
-    # and this step will be failing. This is acceptable.
-    # On the other end, we want to be notified if this happens on merge, or
-    # on schedule.
-    continue-on-error: ${{ github.event_name == 'pull_request'}}
+    # serves two purposes:
+    # - Don't skip this job if dependent jobs have failed.
+    # - On a fork, we don't have the secrets to authenticate to AWS.
+    if: ${{ ! github.event.repository.fork && ! github.event.pull_request.head.repo.fork }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -193,7 +190,5 @@ jobs:
           # Checks if any of the jobs have failed.
           #
           # needs.*.result is returns the list of all success statuses as an
-          # array, i.e. ['success', 'failure, 'success']
-          # join() converts the array to a string 'successfailuresuccess'
-          # contains() checks whether the string contains failure
-          metric-value: ${{ ! contains(join(needs.*.result, ''), 'failure') && ! contains(join(needs.*.result, ''), 'cancelled') }}
+          # array, e.g. ['success', 'failure, 'success']
+          metric-value: ${{ ! contains(needs.*.result, 'failure') }}


### PR DESCRIPTION
Gracefully skip CloudWatch on forks and externally-initiated PRs. These fail without the secrets private to this repo.