### PR TITLE
Fix log_workflow_status_to_cloudwatch continuation logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,10 +174,13 @@ jobs:
       - test_environment_linux
       - test_multiple_ros_installations
       - test_ros_binary_install_ubuntu
-    # serves two purposes:
-    # - Don't skip this job if dependent jobs have failed.
-    # - On a fork, we don't have the secrets to authenticate to AWS.
-    if: ${{ ! github.event.repository.fork && ! github.event.pull_request.head.repo.fork }}
+    if: always()  # run even if the dependent jobs have failed to log failures
+    # Allow build reports to fail on pull requests.
+    # When a contribution is made on a fork, the secrets will not be available,
+    # and this step will be failing. This is acceptable.
+    # On the other end, we want to be notified if this happens on merge, or
+    # on schedule.
+    continue-on-error: ${{ github.event_name == 'pull_request'}}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
Currently, the `log_workflow_status_to_cloudwatch` job will be skipped if any of the jobs under `needs` (in this case the `test_environment`, `test_environment_linux`, `test_multiple_ros_installations`, and `test_ros_binary_install_ubuntu` jobs) fails. This pull request fixes that logic.