### PR TITLE
Pin numpy to 1.18.0

### DIFF
--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -40,7 +40,7 @@ const pip3Packages: string[] = [
 	"mock",
 	"mypy",
 	"nose",
-	"numpy",
+	"numpy==1.18.0",
 	"pep8",
 	"pydocstyle",
 	"pyparsing",


### PR DESCRIPTION
Resolves #198 

Pins the version of numpy to work with python 3.6 (kinetic).

Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>