### PR TITLE
Windows: Add in registry key that is expected for ROS 2 Chocolatey.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4183,6 +4183,13 @@ exports.installChocoDependencies = installChocoDependencies;
 function downloadAndInstallRos2NugetPackages() {
     return __awaiter(this, void 0, void 0, function* () {
         yield utils.exec("wget", ["--quiet"].concat(ros2ChocolateyPackagesUrl));
+        // The ROS 2 NUGET Chocolatey packages expect a registry entry of
+        // HKCU\SOFTWARE\Kitware\CMake to exist; if it doesn't, they don't
+        // properly register themselves with CMake and thus downstream software
+        // can't properly find them.  The Windows image that is currently available
+        // to GitHub actions (https://github.com/actions/virtual-environments/blob/win19/20200608.1/images/win/Windows2019-Readme.md)
+        // doesn't seem to have this key, so add it by hand here.
+        yield utils.exec("reg", ["add", "HKCU\\SOFTWARE\\Kitware\\CMake", "/f"]);
         return utils.exec("choco", chocoCommandLine.concat("--source", ".").concat(ros2ChocolateyPackages));
     });
 }

--- a/src/package_manager/chocolatey.ts
+++ b/src/package_manager/chocolatey.ts
@@ -47,6 +47,13 @@ export async function installChocoDependencies(): Promise<number> {
  */
 export async function downloadAndInstallRos2NugetPackages(): Promise<number> {
 	await utils.exec("wget", ["--quiet"].concat(ros2ChocolateyPackagesUrl));
+	// The ROS 2 NUGET Chocolatey packages expect a registry entry of
+	// HKCU\SOFTWARE\Kitware\CMake to exist; if it doesn't, they don't
+	// properly register themselves with CMake and thus downstream software
+	// can't properly find them.  The Windows image that is currently available
+	// to GitHub actions (https://github.com/actions/virtual-environments/blob/win19/20200608.1/images/win/Windows2019-Readme.md)
+	// doesn't seem to have this key, so add it by hand here.
+	await utils.exec("reg", ["add", "HKCU\\SOFTWARE\\Kitware\\CMake", "/f"]);
 	return utils.exec(
 		"choco",
 		chocoCommandLine.concat("--source", ".").concat(ros2ChocolateyPackages)


### PR DESCRIPTION
## Description

Windows: Add in registry key that is expected for ROS 2 Chocolatey.
    
The ROS 2 NUGET Chocolatey packages expect a registry entry of
HKCU\SOFTWARE\Kitware\CMake to exist; if it doesn't, they don't
properly register themselves with CMake and thus downstream software
can't properly find them.  The Windows image that is currently available
to GitHub actions (https://github.com/actions/virtual-environments/blob/win19/20200608.1/images/win/Windows2019-Readme.md)
doesn't seem to have this key, so add it by hand here.

- [x] Does this PR check in generated JS code (npm run build)?
