### PR TITLE
Install colcon-coveragepy-result

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1826,7 +1826,7 @@ const validDistro = [
 ];
 //Determine whether all inputs name supported ROS distributions.
 function validateDistro(requiredRosDistributionsList) {
-    for (let rosDistro of requiredRosDistributionsList) {
+    for (const rosDistro of requiredRosDistributionsList) {
         if (validDistro.indexOf(rosDistro) <= -1) {
             return false;
         }
@@ -1888,6 +1888,7 @@ const pip3Packages = [
     "colcon-cmake==0.2.19",
     "colcon-common-extensions==0.2.1",
     "colcon-core==0.5.5",
+    "colcon-coveragepy-result==0.0.8",
     "colcon-defaults==0.2.4",
     "colcon-lcov-result==0.4.0",
     "colcon-library-path==0.2.1",

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -7,6 +7,7 @@ const pip3Packages: string[] = [
 	"colcon-cmake==0.2.19",
 	"colcon-common-extensions==0.2.1",
 	"colcon-core==0.5.5",
+	"colcon-coveragepy-result==0.0.8",
 	"colcon-defaults==0.2.4",
 	"colcon-lcov-result==0.4.0",
 	"colcon-library-path==0.2.1",


### PR DESCRIPTION
## Description

Install [`colcon-coveragepy-result`](https://github.com/colcon/colcon-coveragepy-result) in preparation for https://github.com/ros-tooling/action-ros-ci/issues/238

- [x] Does this PR check in generated JS code (npm run build)?