### PR TITLE
Remove reviewers from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,3 @@ updates:
     interval: daily
     time: "16:00"
   open-pull-requests-limit: 10
-  reviewers:
-  - ros-tooling/approvers


### PR DESCRIPTION
Signed-off-by: Anas Abou Allaban <allabana@amazon.com>

## Description

On-Call currently takes care of this.
No need to inform reviewers in ros-tooling.

- [X] Does this PR check in generated JS code (npm run build)?
