### PR TITLE
Add rolling to list of valid ros distros and update tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,11 @@ jobs:
         ros_distribution:
           - kinetic
           - melodic
+          - noetic
           - dashing
           - eloquent
+          - foxy
+          - rolling
 
         # Define the Docker image(s) associated with each ROS distribution.
         # The include syntax allows additional variables to be defined, like
@@ -119,6 +122,11 @@ jobs:
             ros_distribution: melodic
             ros_version: 1
 
+          # Noetic Ninjemys (May 2020 - May 2025)
+          - docker_image: ubuntu:focal
+            ros_distribution: noetic
+            ros_version: 1
+
           # Dashing Diademata (May 2019 - May 2021)
           - docker_image: ubuntu:bionic
             ros_distribution: dashing
@@ -127,6 +135,16 @@ jobs:
           # Eloquent Elusor (November 2019 - November 2020)
           - docker_image: ubuntu:bionic
             ros_distribution: eloquent
+            ros_version: 2
+
+          # Foxy Fitzroy (June 2020 - May 2023)
+          - docker_image: ubuntu:focal
+            ros_distribution: foxy
+            ros_version: 2
+
+          # Rolling Ridley (see REP 2002: https://www.ros.org/reps/rep-2002.html)
+          - docker_image: ubuntu:focal
+            ros_distribution: rolling
             ros_version: 2
 
     # ROS 1 tests only run on Ubuntu

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,11 @@ inputs:
       - "" (no value) - no ROS binary installation
       - kinetic
       - melodic
+      - noetic
       - dashing
       - eloquent
+      - foxy
+      - rolling
 
       Multiple values can be passed using a whitespace delimited list
       "melodic dashing".

--- a/dist/index.js
+++ b/dist/index.js
@@ -1823,6 +1823,7 @@ const validDistro = [
     "dashing",
     "eloquent",
     "foxy",
+    "rolling"
 ];
 //Determine whether all inputs name supported ROS distributions.
 function validateDistro(requiredRosDistributionsList) {
@@ -4272,6 +4273,7 @@ class HTTPError extends Error {
 }
 exports.HTTPError = HTTPError;
 const IS_WINDOWS = process.platform === 'win32';
+const IS_MAC = process.platform === 'darwin';
 const userAgent = 'actions/tool-cache';
 /**
  * Download a tool from an url and stream it into a file
@@ -4487,6 +4489,36 @@ function extractTar(file, dest, flags = 'xz') {
     });
 }
 exports.extractTar = extractTar;
+/**
+ * Extract a xar compatible archive
+ *
+ * @param file     path to the archive
+ * @param dest     destination directory. Optional.
+ * @param flags    flags for the xar. Optional.
+ * @returns        path to the destination directory
+ */
+function extractXar(file, dest, flags = []) {
+    return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(IS_MAC, 'extractXar() not supported on current OS');
+        assert_1.ok(file, 'parameter "file" is required');
+        dest = yield _createExtractFolder(dest);
+        let args;
+        if (flags instanceof Array) {
+            args = flags;
+        }
+        else {
+            args = [flags];
+        }
+        args.push('-x', '-C', dest, '-f', file);
+        if (core.isDebug()) {
+            args.push('-v');
+        }
+        const xarPath = yield io.which('xar', true);
+        yield exec_1.exec(`"${xarPath}"`, _unique(args));
+        return dest;
+    });
+}
+exports.extractXar = extractXar;
 /**
  * Extract a zip
  *
@@ -4794,6 +4826,13 @@ function _getGlobal(key, defaultValue) {
     const value = global[key];
     /* eslint-enable @typescript-eslint/no-explicit-any */
     return value !== undefined ? value : defaultValue;
+}
+/**
+ * Returns an array of unique values.
+ * @param values Values to make unique.
+ */
+function _unique(values) {
+    return Array.from(new Set(values));
 }
 //# sourceMappingURL=tool-cache.js.map
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,6 +52,7 @@ const validDistro: string[] = [
 	"dashing",
 	"eloquent",
 	"foxy",
+	"rolling"
 ];
 
 //Determine whether all inputs name supported ROS distributions.


### PR DESCRIPTION
## Description

This adds Rolling to the list of valid ROS distros so that its binaries can be installed. It also updates the test jobs with the newer ROS (1 and 2) distros.

This isn't strictly related to/required for https://github.com/ros-tooling/action-ros-ci/pull/290, but it goes in the same direction, i.e. enabling users to develop & test against Rolling.

- [x] Does this PR check in generated JS code (npm run build)?
