### PR TITLE
Upgrade pip3 before installing dependencies with it. Fixes newest cryptography error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1221,6 +1221,8 @@ function runLinux() {
         // pip3 dependencies need to be installed after the APT ones, as pip3
         // modules such as cryptography requires python-dev to be installed,
         // because they rely on Python C headers.
+        // Upgrade pip to latest before installing other dependencies, the apt version is very old
+        yield pip.runPython3PipInstall(['pip']);
         yield pip.installPython3Dependencies();
         // Initializes rosdep
         yield utils.exec("sudo", ["rosdep", "init"]);

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -120,6 +120,8 @@ export async function runLinux() {
 	// pip3 dependencies need to be installed after the APT ones, as pip3
 	// modules such as cryptography requires python-dev to be installed,
 	// because they rely on Python C headers.
+	// Upgrade pip to latest before installing other dependencies, the apt version is very old
+	await pip.runPython3PipInstall(['pip']);
 	await pip.installPython3Dependencies();
 
 	// Initializes rosdep


### PR DESCRIPTION
## Description
- [x] Does this PR check in generated JS code (npm run build)?

Fixes error found at e.g.  https://github.com/ros-tooling/action-ros-ci/actions/runs/409583561 - a new version of `cryptography` highlighted that we have a very old version of pip3 on Ubuntu Xenial. Upgrading it to latest fixes the issue.

Easily reproducible

```
# Dockerfile
from ubuntu:xenial
run apt-get update && apt-get install python3-pip
# Uncomment the below line and it'll fix the build, without it you can see the breakage
# run pip3 install -U pip 
run pip3 install cryptography
```