### PR TITLE
Only try to run PR auto-approve/merge if the user is dependabot

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -8,8 +8,8 @@ jobs:
   # (see .dependabot/config.yml for more info).
   auto-approve-dependabot:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     steps:
       - uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -15,9 +15,9 @@ jobs:
     # Automatically merge approved and green dependabot PRs.
     auto-merge-dependabot:
       runs-on: ubuntu-latest
+      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
       steps:
         - uses: pascalgn/automerge-action@v0.8.4
-          if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
           env:
             GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
             MERGE_LABELS: "dependencies"


### PR DESCRIPTION
Previously it would fetch and build the autoapprove/automerge actions for everything, taking a few seconds (adds up when a lot of automerges are triggered by all the `on:` conditions). Now it won't even try to run the job



## Description

- [ ] Does this PR check in generated JS code (npm run build)?