### PR TITLE
Bump colcon-lcov-result to 0.5.0

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1923,7 +1923,7 @@ const pip3Packages = [
     "colcon-core==0.5.5",
     "colcon-coveragepy-result==0.0.8",
     "colcon-defaults==0.2.4",
-    "colcon-lcov-result==0.4.0",
+    "colcon-lcov-result==0.5.0",
     "colcon-library-path==0.2.1",
     "colcon-metadata==0.2.4",
     "colcon-mixin==0.1.6",

--- a/dist/index.js
+++ b/dist/index.js
@@ -1920,7 +1920,7 @@ const pip3Packages = [
     "colcon-cd==0.1.1",
     "colcon-cmake==0.2.19",
     "colcon-common-extensions==0.2.1",
-    "colcon-core==0.5.5",
+    "colcon-core==0.5.6",
     "colcon-coveragepy-result==0.0.8",
     "colcon-defaults==0.2.4",
     "colcon-lcov-result==0.5.0",

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -6,7 +6,7 @@ const pip3Packages: string[] = [
 	"colcon-cd==0.1.1",
 	"colcon-cmake==0.2.19",
 	"colcon-common-extensions==0.2.1",
-	"colcon-core==0.5.5",
+	"colcon-core==0.5.6",
 	"colcon-coveragepy-result==0.0.8",
 	"colcon-defaults==0.2.4",
 	"colcon-lcov-result==0.5.0",

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -9,7 +9,7 @@ const pip3Packages: string[] = [
 	"colcon-core==0.5.5",
 	"colcon-coveragepy-result==0.0.8",
 	"colcon-defaults==0.2.4",
-	"colcon-lcov-result==0.4.0",
+	"colcon-lcov-result==0.5.0",
 	"colcon-library-path==0.2.1",
 	"colcon-metadata==0.2.4",
 	"colcon-mixin==0.1.6",


### PR DESCRIPTION
Not a huge difference, see https://github.com/colcon/colcon-lcov-result/compare/0.4.0...0.5.0.

This also bumps colcon-core to 0.5.6 since colcon-lcov-result>=0.4.1 requires it.

## Description

- [x] Does this PR check in generated JS code (npm run build)?
