### PR TITLE
Do an intermediate upgrade to pip 20 before trying any further, so that xenial can pass and avoid an incompatible version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1220,11 +1220,16 @@ function runLinux() {
         // vcs dependencies (e.g. git), as well as base building packages are not pulled by rosdep, so
         // they are also installed during this stage.
         yield apt.installAptDependencies(installConnext);
-        // pip3 dependencies need to be installed after the APT ones, as pip3
-        // modules such as cryptography requires python-dev to be installed,
-        // because they rely on Python C headers.
-        // Upgrade pip to latest before installing other dependencies, the apt version is very old
+        /* Get the latest version of pip before installing dependencies,
+        the version from apt can be very out of date (v8.0 on xenial)
+        The latest version of pip doesn't support Python3.5 as of v21,
+        but pip 8 doesn't understand the metadata that states this, so we must first
+        make an intermediate upgrade to pip 20, which does understand that information */
+        yield pip.runPython3PipInstall(['pip==20.*']);
         yield pip.runPython3PipInstall(['pip']);
+        /* pip3 dependencies need to be installed after the APT ones, as pip3
+        modules such as cryptography requires python-dev to be installed,
+        because they rely on Python C headers. */
         yield pip.installPython3Dependencies();
         // Initializes rosdep, trying to remove the default file first in case this environment has already done a rosdep init before
         yield utils.exec("sudo", ["bash", "-c", "rm /etc/ros/rosdep/sources.list.d/20-default.list || true"]);

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -119,11 +119,17 @@ export async function runLinux() {
 	// they are also installed during this stage.
 	await apt.installAptDependencies(installConnext);
 
-	// pip3 dependencies need to be installed after the APT ones, as pip3
-	// modules such as cryptography requires python-dev to be installed,
-	// because they rely on Python C headers.
-	// Upgrade pip to latest before installing other dependencies, the apt version is very old
+	/* Get the latest version of pip before installing dependencies,
+	the version from apt can be very out of date (v8.0 on xenial)
+	The latest version of pip doesn't support Python3.5 as of v21,
+	but pip 8 doesn't understand the metadata that states this, so we must first
+	make an intermediate upgrade to pip 20, which does understand that information */
+	await pip.runPython3PipInstall(['pip==20.*']);
 	await pip.runPython3PipInstall(['pip']);
+
+	/* pip3 dependencies need to be installed after the APT ones, as pip3
+	modules such as cryptography requires python-dev to be installed,
+	because they rely on Python C headers. */
 	await pip.installPython3Dependencies();
 
 	// Initializes rosdep, trying to remove the default file first in case this environment has already done a rosdep init before


### PR DESCRIPTION
This is expected to make the build go from red to green (the Xenial-based builds are failing)

See https://pip.pypa.io/en/stable/news/#id1 release notes for v21.0, which states that support for python 3.5 is dropped

See https://github.com/pypa/pip/issues/9515 for some more information




## Description

- [ ] Does this PR check in generated JS code (npm run build)?