### PR TITLE
Install bison with brew for macOS

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2052,6 +2052,7 @@ const utils = __importStar(__webpack_require__(163));
 const brewDependencies = [
     "asio",
     "assimp",
+    "bison",
     "bullet",
     "cmake",
     "console_bridge",

--- a/src/package_manager/brew.ts
+++ b/src/package_manager/brew.ts
@@ -3,6 +3,7 @@ import * as utils from "../utils";
 const brewDependencies: string[] = [
 	"asio",
 	"assimp",
+	"bison",
 	"bullet",
 	"cmake",
 	"console_bridge",


### PR DESCRIPTION
Needed since this recently became a cyclonedds dependency. See failure (missing dependency) on macOS here: https://github.com/ros-tooling/libstatistics_collector/pull/92

Relates to https://github.com/ros2/ci/pull/546

Relates to https://github.com/ros2/ros2_documentation/pull/1191

## Description

- [x] Does this PR check in generated JS code (npm run build)?
