### PR TITLE
Fix groups in action output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1279,7 +1279,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.installAptDependencies = exports.runAptGetInstall = void 0;
-const exec = __importStar(__webpack_require__(986));
 const utils = __importStar(__webpack_require__(163));
 const CONNEXT_APT_PACKAGE_NAME = "rti-connext-dds-5.3.1"; // RTI Connext
 const aptCommandLine = [
@@ -1367,7 +1366,7 @@ function determineDistribCodename() {
                 distribCodename += data.toString();
             },
         };
-        yield exec.exec("bash", ["-c", 'source /etc/lsb-release ; echo -n "$DISTRIB_CODENAME"'], options);
+        yield utils.exec("bash", ["-c", 'source /etc/lsb-release ; echo -n "$DISTRIB_CODENAME"'], options);
         return distribCodename;
     });
 }

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -91,7 +91,7 @@ async function determineDistribCodename(): Promise<string> {
 			distribCodename += data.toString();
 		},
 	};
-	await exec.exec(
+	await utils.exec(
 		"bash",
 		["-c", 'source /etc/lsb-release ; echo -n "$DISTRIB_CODENAME"'],
 		options


### PR DESCRIPTION
This fixes the action output after the `source /etc/lsb-release ; echo -n "$DISTRIB_CODENAME"` command:

before:

![Screenshot from 2021-04-08 15-11-42](https://user-images.githubusercontent.com/3717345/114083333-d1e8e580-987c-11eb-8ed3-6741fa524c11.png)

after:

![Screenshot from 2021-04-08 15-32-32](https://user-images.githubusercontent.com/3717345/114085730-bc28ef80-987f-11eb-9457-42d34ec47264.png)

I think the `echo -n` command was messing with the special GitHub action output formatting (`::group::`) because there was no newline at the end (`-n` flag).

This PR changes the way that the `echo` command is executed so that it's inside a group. This way it ends up not messing with the next command/group.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>

## Description

- [x] Does this PR check in generated JS code (npm run build)?
