### PR TITLE
Lower scheduled jobs frequency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ on:
       - master
       - "releases/*"
   schedule:
-    # Run the CI automatically every hour to look for flakyness.
-    - cron: "0 * * * *"
+    # Run the CI automatically twice per day to look for flakyness.
+    - cron: "0 */12 * * *"
 
 defaults:
   run:


### PR DESCRIPTION
Similar to https://github.com/ros-tooling/action-ros-ci/pull/593

CI isn't as bad here, but twice per day should be good enough.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>