### PR TITLE
Change directory before running `pip` in setup

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5579,7 +5579,7 @@ function runLinux() {
         // Before running `pip`, change directory to where a `setup.cfg` should not exist.
         // This prevents `pip` from installing to `install_scripts` as specified in the
         // `setup.cfg`, which for most packages in the ROS ecosystem is `$base/lib/<pkg-name>`.
-        yield utils.exec("cd", ["/"]);
+        yield utils.exec("bash", ["-c", "cd", "/"]);
         /* Get the latest version of pip before installing dependencies,
         the version from apt can be very out of date (v8.0 on xenial)
         The latest version of pip doesn't support Python3.5 as of v21,
@@ -5592,7 +5592,7 @@ function runLinux() {
         because they rely on Python C headers. */
         yield pip.installPython3Dependencies();
         // Return to the original directory.
-        yield utils.exec("cd", ["-"]);
+        yield utils.exec("bash", ["-c", "cd", "-"]);
         // Initializes rosdep, trying to remove the default file first in case this environment has already done a rosdep init before
         yield utils.exec("sudo", [
             "bash",

--- a/dist/index.js
+++ b/dist/index.js
@@ -5576,6 +5576,10 @@ function runLinux() {
         // vcs dependencies (e.g. git), as well as base building packages are not pulled by rosdep, so
         // they are also installed during this stage.
         yield apt.installAptDependencies(installConnext);
+        // Before running `pip`, change directory to where a `setup.cfg` should not exist.
+        // This prevents `pip` from installing to `install_scripts` as specified in the
+        // `setup.cfg`, which for most packages in the ROS ecosystem is `$base/lib/<pkg-name>`.
+        yield utils.exec("cd", ["/"]);
         /* Get the latest version of pip before installing dependencies,
         the version from apt can be very out of date (v8.0 on xenial)
         The latest version of pip doesn't support Python3.5 as of v21,
@@ -5587,6 +5591,8 @@ function runLinux() {
         modules such as cryptography requires python-dev to be installed,
         because they rely on Python C headers. */
         yield pip.installPython3Dependencies();
+        // Return to the original directory.
+        yield utils.exec("cd", ["-"]);
         // Initializes rosdep, trying to remove the default file first in case this environment has already done a rosdep init before
         yield utils.exec("sudo", [
             "bash",

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -122,10 +122,10 @@ export async function runLinux() {
 	// they are also installed during this stage.
 	await apt.installAptDependencies(installConnext);
 
-    // Before running `pip`, change directory to where a `setup.cfg` should not exist.
-    // This prevents `pip` from installing to `install_scripts` as specified in the
-    // `setup.cfg`, which for most packages in the ROS ecosystem is `$base/lib/<pkg-name>`.
-    await utils.exec("cd", ["/"]);
+	// Before running `pip`, change directory to where a `setup.cfg` should not exist.
+	// This prevents `pip` from installing to `install_scripts` as specified in the
+	// `setup.cfg`, which for most packages in the ROS ecosystem is `$base/lib/<pkg-name>`.
+	await utils.exec("cd", ["/"]);
 
 	/* Get the latest version of pip before installing dependencies,
 	the version from apt can be very out of date (v8.0 on xenial)
@@ -140,8 +140,8 @@ export async function runLinux() {
 	because they rely on Python C headers. */
 	await pip.installPython3Dependencies();
 
-    // Return to the original directory.
-    await utils.exec("cd", ["-"]);
+	// Return to the original directory.
+	await utils.exec("cd", ["-"]);
 
 	// Initializes rosdep, trying to remove the default file first in case this environment has already done a rosdep init before
 	await utils.exec("sudo", [

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -122,6 +122,11 @@ export async function runLinux() {
 	// they are also installed during this stage.
 	await apt.installAptDependencies(installConnext);
 
+    // Before running `pip`, change directory to where a `setup.cfg` should not exist.
+    // This prevents `pip` from installing to `install_scripts` as specified in the
+    // `setup.cfg`, which for most packages in the ROS ecosystem is `$base/lib/<pkg-name>`.
+    await utils.exec("cd", ["/"]);
+
 	/* Get the latest version of pip before installing dependencies,
 	the version from apt can be very out of date (v8.0 on xenial)
 	The latest version of pip doesn't support Python3.5 as of v21,
@@ -134,6 +139,9 @@ export async function runLinux() {
 	modules such as cryptography requires python-dev to be installed,
 	because they rely on Python C headers. */
 	await pip.installPython3Dependencies();
+
+    // Return to the original directory.
+    await utils.exec("cd", ["-"]);
 
 	// Initializes rosdep, trying to remove the default file first in case this environment has already done a rosdep init before
 	await utils.exec("sudo", [

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -125,7 +125,7 @@ export async function runLinux() {
 	// Before running `pip`, change directory to where a `setup.cfg` should not exist.
 	// This prevents `pip` from installing to `install_scripts` as specified in the
 	// `setup.cfg`, which for most packages in the ROS ecosystem is `$base/lib/<pkg-name>`.
-	await utils.exec("cd", ["/"]);
+	await utils.exec("bash", ["-c", "cd", "/"]);
 
 	/* Get the latest version of pip before installing dependencies,
 	the version from apt can be very out of date (v8.0 on xenial)
@@ -141,7 +141,7 @@ export async function runLinux() {
 	await pip.installPython3Dependencies();
 
 	// Return to the original directory.
-	await utils.exec("cd", ["-"]);
+	await utils.exec("bash", ["-c", "cd", "-"]);
 
 	// Initializes rosdep, trying to remove the default file first in case this environment has already done a rosdep init before
 	await utils.exec("sudo", [


### PR DESCRIPTION
Will go out of draft following some tests. Should fix #75.

If the current working directory in the setup process
happened to contain a `setup.cfg` file (possible if the
user ran `actions/checkout` on a Python package), then
`pip` will install to the `install_scripts` location
specified in said configuration file. This can lead to
situations such as ros-tooling/setup-ros#75, where `colcon`
(and other Python dependencies) get installed in a
location that is not on the `PATH`.

This commit temporarily changes directory to `/` before
updating `pip` and installing Python dependencies, hence
circumventing the installation of Python packages in non-
standard locations.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>