### PR TITLE
Fix name of 'node-version' input for setup-node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,6 +198,6 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2.2.0
         with:
-          node_version: "12.x"
+          node-version: "12.x"
       - run: .github/workflows/build-and-test.sh
       - uses: ./


### PR DESCRIPTION
I think this was a copy-paste error. The other instances in the file are valid (`node-version`).

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>