### PR TITLE
Fix 'pip* install' for checked out repos containing a root setup.cfg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,6 +182,21 @@ jobs:
       - run: .github/workflows/check-ros2-distribution.sh dashing
       - run: .github/workflows/check-ros-distribution.sh melodic
 
+  test_repo_with_root_setup_cfg:
+    name: "Test with setup.cfg file in root directory (Linux only)"
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:focal
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v2.5.1
+        with:
+          node-version: "12.x"
+      - run: .github/workflows/build-and-test.sh
+      - run: cp .github/workflows/test_setup.cfg setup.cfg
+      - uses: ./ # Uses an action in the root directory
+      - run: colcon --help
+
   test_on_setup_ros_docker_container:
     name: "Test on a setup-ros-docker container"
     runs-on: ubuntu-latest

--- a/.github/workflows/test_setup.cfg
+++ b/.github/workflows/test_setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/package_name
+[install]
+install_scripts=$base/lib/package_name

--- a/dist/index.js
+++ b/dist/index.js
@@ -6141,6 +6141,8 @@ function installAptDependencies(installConnext = false) {
     });
 }
 
+// EXTERNAL MODULE: external "path"
+var external_path_ = __nccwpck_require__(622);
 ;// CONCATENATED MODULE: ./src/package_manager/pip.ts
 var pip_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
@@ -6151,6 +6153,7 @@ var pip_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argu
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+
 
 const pip3Packages = [
     "argcomplete",
@@ -6220,11 +6223,15 @@ function runPython3PipInstall(packages, run_with_sudo) {
     return pip_awaiter(this, void 0, void 0, function* () {
         const sudo_enabled = run_with_sudo === undefined ? true : run_with_sudo;
         const args = pip3CommandLine.concat(packages);
+        // Set CWD to root to avoid running 'pip install' in directory with setup.cfg file
+        const options = {
+            cwd: external_path_.sep,
+        };
         if (sudo_enabled) {
-            return utils_exec("sudo", pip3CommandLine.concat(packages));
+            return utils_exec("sudo", pip3CommandLine.concat(packages), options);
         }
         else {
-            return utils_exec(args[0], args.splice(1));
+            return utils_exec(args[0], args.splice(1), options);
         }
     });
 }
@@ -6240,8 +6247,6 @@ function installPython3Dependencies(run_with_sudo) {
     });
 }
 
-// EXTERNAL MODULE: external "path"
-var external_path_ = __nccwpck_require__(622);
 // EXTERNAL MODULE: external "fs"
 var external_fs_ = __nccwpck_require__(747);
 var external_fs_default = /*#__PURE__*/__nccwpck_require__.n(external_fs_);

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -1,3 +1,5 @@
+import * as im from "@actions/exec/lib/interfaces"; // eslint-disable-line no-unused-vars
+import * as path from "path";
 import * as utils from "../utils";
 
 const pip3Packages: string[] = [
@@ -72,10 +74,14 @@ export async function runPython3PipInstall(
 ): Promise<number> {
 	const sudo_enabled = run_with_sudo === undefined ? true : run_with_sudo;
 	const args = pip3CommandLine.concat(packages);
+	// Set CWD to root to avoid running 'pip install' in directory with setup.cfg file
+	const options: im.ExecOptions = {
+		cwd: path.sep,
+	};
 	if (sudo_enabled) {
-		return utils.exec("sudo", pip3CommandLine.concat(packages));
+		return utils.exec("sudo", pip3CommandLine.concat(packages), options);
 	} else {
-		return utils.exec(args[0], args.splice(1));
+		return utils.exec(args[0], args.splice(1), options);
 	}
 }
 


### PR DESCRIPTION
Fixes #75

Fixes https://github.com/ros-tooling/action-ros-ci/issues/721

Supersedes #408

This makes the `pip install ...` run using `/` as the current working directory.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>