### PR TITLE
Temporarily restrict pip version on Windows to avoid failures

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6617,6 +6617,10 @@ function prepareRos2BuildEnvironment() {
         core.addPath("c:\\program files\\cppcheck");
         yield installChocoDependencies();
         yield downloadAndInstallRos2NugetPackages();
+        // Avoid version of pip that breaks Windows GitHub actions. See:
+        // * https://github.com/ros-tooling/action-ros-ci/pull/719#issuecomment-1030318146
+        // * https://github.com/actions/virtual-environments/issues/5027#issuecomment-1031113617
+        yield runPython3PipInstall(["pip!=22.0.*"], false);
         yield installPython3Dependencies(false);
         yield runPython3PipInstall(setup_ros_windows_pip3Packages, false);
         yield runPython3PipInstall(["rosdep", "vcstool"], false);

--- a/dist/index.js
+++ b/dist/index.js
@@ -6620,7 +6620,9 @@ function prepareRos2BuildEnvironment() {
         // Avoid version of pip that breaks Windows GitHub actions. See:
         // * https://github.com/ros-tooling/action-ros-ci/pull/719#issuecomment-1030318146
         // * https://github.com/actions/virtual-environments/issues/5027#issuecomment-1031113617
-        yield runPython3PipInstall(["pip!=22.0.*"], false);
+        yield utils_exec("python", ["-m", "pip", "install", "-U", "pip!=22.0.*"], {
+            cwd: external_path_.sep,
+        });
         yield installPython3Dependencies(false);
         yield runPython3PipInstall(setup_ros_windows_pip3Packages, false);
         yield runPython3PipInstall(["rosdep", "vcstool"], false);

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -46,6 +46,12 @@ async function prepareRos2BuildEnvironment() {
 	core.addPath("c:\\program files\\cppcheck");
 	await chocolatey.installChocoDependencies();
 	await chocolatey.downloadAndInstallRos2NugetPackages();
+
+	// Avoid version of pip that breaks Windows GitHub actions. See:
+	// * https://github.com/ros-tooling/action-ros-ci/pull/719#issuecomment-1030318146
+	// * https://github.com/actions/virtual-environments/issues/5027#issuecomment-1031113617
+	await pip.runPython3PipInstall(["pip!=22.0.*"], false);
+
 	await pip.installPython3Dependencies(false);
 	await pip.runPython3PipInstall(pip3Packages, false);
 	await pip.runPython3PipInstall(["rosdep", "vcstool"], false);

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -50,7 +50,9 @@ async function prepareRos2BuildEnvironment() {
 	// Avoid version of pip that breaks Windows GitHub actions. See:
 	// * https://github.com/ros-tooling/action-ros-ci/pull/719#issuecomment-1030318146
 	// * https://github.com/actions/virtual-environments/issues/5027#issuecomment-1031113617
-	await pip.runPython3PipInstall(["pip!=22.0.*"], false);
+	await utils.exec("python", ["-m", "pip", "install", "-U", "pip!=22.0.*"], {
+		cwd: path.sep,
+	});
 
 	await pip.installPython3Dependencies(false);
 	await pip.runPython3PipInstall(pip3Packages, false);


### PR DESCRIPTION
See https://github.com/ros-tooling/action-ros-ci/pull/719#issuecomment-1030318146

Once pip releases a new version with the fix (https://github.com/pypa/pip/issues/10875), we can revert this.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>