### PR TITLE
Jammy Transition - Additional Work Required

### DIFF
--- a/.github/workflows/check-ros2-distribution.sh
+++ b/.github/workflows/check-ros2-distribution.sh
@@ -2,7 +2,7 @@
 #
 # ./check-ros-distribution.sh <ROS distribution>
 # ROS distribution must match the directory name for this distribution
-# in /opt. E.g. dashing
+# in /opt. E.g. galactic
 
 readonly ROS_DISTRIBUTION="$1"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         docker_image:
           - "ubuntu:bionic"
           - "ubuntu:focal"
+          - "ubuntu:jammy"
     container:
       image: ${{ matrix.docker_image }}
     steps:
@@ -71,6 +72,8 @@ jobs:
           - foxy
           # Galactic Geochelone (May 2021 - November 2022)
           - galactic
+          # Rolling Ridley (No End-Of-Life)
+          - rolling
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.0.0

--- a/README.md
+++ b/README.md
@@ -212,13 +212,11 @@ jobs:
     strategy:
       matrix:
         ros_distribution:
-          - kinetic
           - melodic
           - noetic
-          - dashing
-          - eloquent
           - foxy
           - galactic
+          - rolling
 
         # Define the Docker image(s) associated with each ROS distribution.
         # The include syntax allows additional variables to be defined, like
@@ -250,6 +248,11 @@ jobs:
           # Galactic Geochelone (May 2021 - November 2022)
           - docker_image: ubuntu:focal
             ros_distribution: galactic
+            ros_version: 2
+          
+          # Rolling Ridley (No End-Of-Life)
+          - docker_image: ubuntu:jammy
+            ros_distribution: rolling
             ros_version: 2
 
     container:

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The workflow `test` is iterating on all ROS 2 distributions, on macOS, and Windo
 The workflow `test_docker` is iterating on all ROS and ROS 2 distributions, for all supported Ubuntu distributions, using Docker.
 The test matrix associates each distribution with one Docker image.
 This is required to ensure that the appropriate Ubuntu container is used.
-For example, Kinetic requires `xenial`, Dashing requires `bionic`, Galactic requires `focal`, etc.
+For example, Galactic requires `focal`, Humble requires `jammy`, etc.
 
 ```yaml
 jobs:
@@ -195,8 +195,6 @@ jobs:
       matrix:
         os: [macOS-latest, windows-latest]
         ros_distribution: # Only include ROS 2 distributions, as ROS 1 does not support macOS and Windows.
-          - dashing
-          - eloquent
           - foxy
           - galactic
     steps:
@@ -231,33 +229,18 @@ jobs:
         # https://ros.org/reps/rep-0003.html
         # https://ros.org/reps/rep-2000.html
         include:
-          # Kinetic Kame (May 2016 - May 2021)
-          - docker_image: ubuntu:xenial
-            ros_distribution: kinetic
-            # Setting ros_version is helpful to customize the workflow
-            # depending on whether a ROS 1, or ROS 2 is being tested.
-            # See 'if: ros_version ==' below for an example.
-            ros_version: 1
-
           # Melodic Morenia (May 2018 - May 2023)
           - docker_image: ubuntu:bionic
             ros_distribution: melodic
+            # Setting ros_version is helpful to customize the workflow
+            # depending on whether a ROS 1, or ROS 2 is being tested.
+            # See 'if: ros_version ==' below for an example.
             ros_version: 1
 
           # Noetic Ninjemys (May 2020 - May 2025)
           - docker_image: ubuntu:focal
             ros_distribution: noetic
             ros_version: 1
-
-          # Dashing Diademata (May 2019 - May 2021)
-          - docker_image: ubuntu:bionic
-            ros_distribution: dashing
-            ros_version: 2
-
-          # Eloquent Elusor (November 2019 - November 2020)
-          - docker_image: ubuntu:bionic
-            ros_distribution: eloquent
-            ros_version: 2
 
           # Foxy Fitzroy (June 2020 - May 2023)
           - docker_image: ubuntu:focal

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -54,12 +54,8 @@ describe("required-ros-distributions/melodic workflow tests", () => {
 
 describe("validate distribution test", () => {
 	it("test valid", async () => {
-		await expect(utils.validateDistro(["kinetic"])).toBe(true);
-		await expect(utils.validateDistro(["lunar"])).toBe(true);
 		await expect(utils.validateDistro(["melodic"])).toBe(true);
 		await expect(utils.validateDistro(["noetic"])).toBe(true);
-		await expect(utils.validateDistro(["dashing"])).toBe(true);
-		await expect(utils.validateDistro(["eloquent"])).toBe(true);
 		await expect(utils.validateDistro(["foxy"])).toBe(true);
 		await expect(utils.validateDistro(["galactic"])).toBe(true);
 		await expect(utils.validateDistro(["rolling"])).toBe(true);
@@ -76,10 +72,13 @@ describe("validate distribution test", () => {
 		await expect(utils.validateDistro(["hydro"])).toBe(false);
 		await expect(utils.validateDistro(["indigo"])).toBe(false);
 		await expect(utils.validateDistro(["jade"])).toBe(false);
+		await expect(utils.validateDistro(["kinetic"])).toBe(false);
 		//ROS2 End-of-Life
 		await expect(utils.validateDistro(["ardent"])).toBe(false);
 		await expect(utils.validateDistro(["bouncy"])).toBe(false);
 		await expect(utils.validateDistro(["crystal"])).toBe(false);
+		await expect(utils.validateDistro(["dashing"])).toBe(false);
+		await expect(utils.validateDistro(["eloquent"])).toBe(false);
 		// Does not exist or not all valid
 		await expect(utils.validateDistro(["foxy", "doesntexist"])).toBe(false);
 		await expect(utils.validateDistro(["master"])).toBe(false);

--- a/action.yml
+++ b/action.yml
@@ -26,17 +26,14 @@ inputs:
 
       Allowed ROS distributions
       - "" (no value) - no ROS binary installation
-      - kinetic
       - melodic
       - noetic
-      - dashing
-      - eloquent
       - foxy
       - galactic
       - rolling
 
       Multiple values can be passed using a whitespace delimited list
-      "melodic dashing".
+      "noetic galactic".
     required: false
     default: ""
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -6055,7 +6055,6 @@ const aptDependencies = [
     "lcov",
     "libc++-dev",
     "libc++abi-dev",
-    "python",
     "python3-catkin-pkg-modules",
     "python3-pip",
     "python3-vcstool",

--- a/dist/index.js
+++ b/dist/index.js
@@ -6372,17 +6372,17 @@ function runLinux() {
         external_fs_default().writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
         yield utils_exec("sudo", ["apt-key", "add", keyFilePath]);
         const distribCodename = yield utils_exec("lsb_release", ["-sc"]);
-        if (distribCodename in distrosRequiringRosUbuntu) {
+        if (distrosRequiringRosUbuntu.includes(distribCodename)) {
             yield utils_exec("sudo", [
                 "bash",
                 "-c",
-                `echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`,
+                `echo "deb http://packages.ros.org/ros/ubuntu ${distribCodename} main" > /etc/apt/sources.list.d/ros-latest.list`,
             ]);
         }
         yield utils_exec("sudo", [
             "bash",
             "-c",
-            `echo "deb http://packages.ros.org/ros2${use_ros2_testing ? "-testing" : ""}/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list`,
+            `echo "deb http://packages.ros.org/ros2${use_ros2_testing ? "-testing" : ""}/ubuntu ${distribCodename} main" > /etc/apt/sources.list.d/ros2-latest.list`,
         ]);
         yield utils_exec("sudo", ["apt-get", "update"]);
         // Install rosdep and vcs, as well as FastRTPS dependencies, OpenSplice, and

--- a/dist/index.js
+++ b/dist/index.js
@@ -6004,12 +6004,8 @@ function getRequiredRosDistributions() {
 }
 //list of valid linux distributions
 const validDistro = [
-    "kinetic",
-    "lunar",
     "melodic",
     "noetic",
-    "dashing",
-    "eloquent",
     "foxy",
     "galactic",
     "rolling",
@@ -6603,8 +6599,6 @@ var setup_ros_windows_awaiter = (undefined && undefined.__awaiter) || function (
 
 
 const binaryReleases = {
-    dashing: "https://github.com/ros2/ros2/releases/download/release-dashing-20210610/ros2-dashing-20210610-windows-amd64.zip",
-    eloquent: "https://github.com/ros2/ros2/releases/download/release-eloquent-20200124/ros2-eloquent-20200124-windows-release-amd64.zip",
     foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20210902/ros2-foxy-20210902-windows-release-amd64.zip",
     galactic: "https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-windows-release-amd64.zip",
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -6024,6 +6024,13 @@ function validateDistro(requiredRosDistributionsList) {
     return true;
 }
 
+// List of linux distributions that need http://packages.ros.org/ros/ubuntu APT repo
+const distrosRequiringRosUbuntu = [
+    "bionic",
+    "focal",
+    "xenial",
+];
+
 ;// CONCATENATED MODULE: ./src/package_manager/apt.ts
 var apt_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
@@ -6364,11 +6371,14 @@ function runLinux() {
         const keyFilePath = external_path_.join(workspace, "ros.key");
         external_fs_default().writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
         yield utils_exec("sudo", ["apt-key", "add", keyFilePath]);
-        // yield utils_exec("sudo", [
-        //     "bash",
-        //     "-c",
-        //     `echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`,
-        // ]);
+        const distribCodename = yield utils.exec("bash", ["lsb_release", "-sc"]);
+        if (distribCodename in distrosRequiringRosUbuntu) {
+            yield utils_exec("sudo", [
+                "bash",
+                "-c",
+                `echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`,
+            ]);
+        }
         yield utils_exec("sudo", [
             "bash",
             "-c",

--- a/dist/index.js
+++ b/dist/index.js
@@ -6070,9 +6070,18 @@ const distributionSpecificAptDependencies = {
         // python3-rosdep is conflicting with ros-melodic-desktop-full,
         // and should not be used here. See ros-tooling/setup-ros#74
         "python-rosdep",
+        // python required for sourcing setup.sh
+        "python",
     ],
     focal: [
         // python-rosdep does not exist on Focal, so python3-rosdep is used.
+        // The issue with ros-melodic-desktop-full is also non-applicable.
+        "python3-rosdep",
+        // python required for sourcing setup.sh
+        "python",
+    ],
+    jammy: [
+        // python-rosdep does not exist on Jammy, so python3-rosdep is used.
         // The issue with ros-melodic-desktop-full is also non-applicable.
         "python3-rosdep",
     ],
@@ -6082,6 +6091,8 @@ const distributionSpecificAptDependencies = {
         // python3-rosdep is conflicting with ros-melodic-desktop-full,
         // and should not be used here. See ros-tooling/setup-ros#74
         "python-rosdep",
+        // python required for sourcing setup.sh
+        "python",
     ],
 };
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -6371,7 +6371,7 @@ function runLinux() {
         const keyFilePath = external_path_.join(workspace, "ros.key");
         external_fs_default().writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
         yield utils_exec("sudo", ["apt-key", "add", keyFilePath]);
-        const distribCodename = yield utils_exec("bash", ["lsb_release", "-sc"]);
+        const distribCodename = yield utils_exec("bash", ["-c", "lsb_release", "-sc"]);
         if (distribCodename in distrosRequiringRosUbuntu) {
             yield utils_exec("sudo", [
                 "bash",

--- a/dist/index.js
+++ b/dist/index.js
@@ -6077,6 +6077,11 @@ const distributionSpecificAptDependencies = {
         // The issue with ros-melodic-desktop-full is also non-applicable.
         "python3-rosdep",
     ],
+    jammy: [
+        // python-rosdep does not exist on Jammy, so python3-rosdep is used.
+        // The issue with ros-melodic-desktop-full is also non-applicable.
+        "python3-rosdep",
+    ],
     xenial: [
         // OpenSplice
         "libopensplice69",

--- a/dist/index.js
+++ b/dist/index.js
@@ -6371,7 +6371,7 @@ function runLinux() {
         const keyFilePath = external_path_.join(workspace, "ros.key");
         external_fs_default().writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
         yield utils_exec("sudo", ["apt-key", "add", keyFilePath]);
-        const distribCodename = yield utils_exec("lsb_release", ["-sc"]);
+        const distribCodename = yield determineDistribCodename();
         console.log("distribCodename is " + distribCodename);
         if (distrosRequiringRosUbuntu.includes(distribCodename)) {
             yield utils_exec("sudo", [

--- a/dist/index.js
+++ b/dist/index.js
@@ -6028,7 +6028,6 @@ function validateDistro(requiredRosDistributionsList) {
 const distrosRequiringRosUbuntu = [
     "bionic",
     "focal",
-    "xenial",
 ];
 
 ;// CONCATENATED MODULE: ./src/package_manager/apt.ts
@@ -6091,15 +6090,6 @@ const distributionSpecificAptDependencies = {
         // python-rosdep does not exist on Jammy, so python3-rosdep is used.
         // The issue with ros-melodic-desktop-full is also non-applicable.
         "python3-rosdep",
-    ],
-    xenial: [
-        // OpenSplice
-        "libopensplice69",
-        // python3-rosdep is conflicting with ros-melodic-desktop-full,
-        // and should not be used here. See ros-tooling/setup-ros#74
-        "python-rosdep",
-        // python required for sourcing setup.sh
-        "python",
     ],
 };
 /**
@@ -6215,7 +6205,7 @@ const pip3Packages = [
     "mock",
     "mypy",
     "nose",
-    "numpy==1.18.0",
+    "numpy",
     "pep8",
     "pydocstyle",
     "pyparsing",
@@ -6391,9 +6381,9 @@ function runLinux() {
         // they are also installed during this stage.
         yield installAptDependencies(installConnext);
         /* Get the latest version of pip before installing dependencies,
-        the version from apt can be very out of date (v8.0 on xenial)
+        the version from apt can be very out of date (v9.0 on bionic)
         The latest version of pip doesn't support Python3.5 as of v21,
-        but pip 8 doesn't understand the metadata that states this, so we must first
+        but pip 9 doesn't understand the metadata that states this, so we must first
         make an intermediate upgrade to pip 20, which does understand that information */
         yield runPython3PipInstall(["pip==20.*"]);
         yield runPython3PipInstall(["pip"]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -6371,7 +6371,7 @@ function runLinux() {
         const keyFilePath = external_path_.join(workspace, "ros.key");
         external_fs_default().writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
         yield utils_exec("sudo", ["apt-key", "add", keyFilePath]);
-        const distribCodename = yield utils.exec("bash", ["lsb_release", "-sc"]);
+        const distribCodename = yield utils_exec("bash", ["lsb_release", "-sc"]);
         if (distribCodename in distrosRequiringRosUbuntu) {
             yield utils_exec("sudo", [
                 "bash",

--- a/dist/index.js
+++ b/dist/index.js
@@ -6076,11 +6076,6 @@ const distributionSpecificAptDependencies = {
         // The issue with ros-melodic-desktop-full is also non-applicable.
         "python3-rosdep",
     ],
-    jammy: [
-        // python-rosdep does not exist on Jammy, so python3-rosdep is used.
-        // The issue with ros-melodic-desktop-full is also non-applicable.
-        "python3-rosdep",
-    ],
     xenial: [
         // OpenSplice
         "libopensplice69",

--- a/dist/index.js
+++ b/dist/index.js
@@ -6372,6 +6372,7 @@ function runLinux() {
         external_fs_default().writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
         yield utils_exec("sudo", ["apt-key", "add", keyFilePath]);
         const distribCodename = yield utils_exec("lsb_release", ["-sc"]);
+        console.log("distribCodename is " + distribCodename);
         if (distrosRequiringRosUbuntu.includes(distribCodename)) {
             yield utils_exec("sudo", [
                 "bash",

--- a/dist/index.js
+++ b/dist/index.js
@@ -6372,7 +6372,6 @@ function runLinux() {
         external_fs_default().writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
         yield utils_exec("sudo", ["apt-key", "add", keyFilePath]);
         const distribCodename = yield determineDistribCodename();
-        console.log("distribCodename is " + distribCodename);
         if (distrosRequiringRosUbuntu.includes(distribCodename)) {
             yield utils_exec("sudo", [
                 "bash",

--- a/dist/index.js
+++ b/dist/index.js
@@ -6371,7 +6371,7 @@ function runLinux() {
         const keyFilePath = external_path_.join(workspace, "ros.key");
         external_fs_default().writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
         yield utils_exec("sudo", ["apt-key", "add", keyFilePath]);
-        const distribCodename = yield utils_exec("bash", ["-c", "lsb_release", "-sc"]);
+        const distribCodename = yield utils_exec("lsb_release", ["-sc"]);
         if (distribCodename in distrosRequiringRosUbuntu) {
             yield utils_exec("sudo", [
                 "bash",

--- a/dist/index.js
+++ b/dist/index.js
@@ -6354,11 +6354,11 @@ function runLinux() {
         const keyFilePath = external_path_.join(workspace, "ros.key");
         external_fs_default().writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
         yield utils_exec("sudo", ["apt-key", "add", keyFilePath]);
-        yield utils_exec("sudo", [
-            "bash",
-            "-c",
-            `echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`,
-        ]);
+        // yield utils_exec("sudo", [
+        //     "bash",
+        //     "-c",
+        //     `echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`,
+        // ]);
         yield utils_exec("sudo", [
             "bash",
             "-c",

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -47,6 +47,11 @@ const distributionSpecificAptDependencies = {
 		// The issue with ros-melodic-desktop-full is also non-applicable.
 		"python3-rosdep",
 	],
+	jammy: [
+		// python-rosdep does not exist on Jammy, so python3-rosdep is used.
+		// The issue with ros-melodic-desktop-full is also non-applicable.
+		"python3-rosdep",
+	],
 	xenial: [
 		// OpenSplice
 		"libopensplice69",

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -40,9 +40,20 @@ const distributionSpecificAptDependencies = {
 		// python3-rosdep is conflicting with ros-melodic-desktop-full,
 		// and should not be used here. See ros-tooling/setup-ros#74
 		"python-rosdep",
+		
+		// python required for sourcing setup.sh
+		"python",
 	],
 	focal: [
 		// python-rosdep does not exist on Focal, so python3-rosdep is used.
+		// The issue with ros-melodic-desktop-full is also non-applicable.
+		"python3-rosdep",
+		
+		// python required for sourcing setup.sh
+		"python",
+	],
+	jammy: [
+		// python-rosdep does not exist on Jammy, so python3-rosdep is used.
 		// The issue with ros-melodic-desktop-full is also non-applicable.
 		"python3-rosdep",
 	],
@@ -53,6 +64,9 @@ const distributionSpecificAptDependencies = {
 		// python3-rosdep is conflicting with ros-melodic-desktop-full,
 		// and should not be used here. See ros-tooling/setup-ros#74
 		"python-rosdep",
+
+		// python required for sourcing setup.sh
+		"python",
 	],
 };
 

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -40,7 +40,7 @@ const distributionSpecificAptDependencies = {
 		// python3-rosdep is conflicting with ros-melodic-desktop-full,
 		// and should not be used here. See ros-tooling/setup-ros#74
 		"python-rosdep",
-		
+
 		// python required for sourcing setup.sh
 		"python",
 	],
@@ -48,7 +48,7 @@ const distributionSpecificAptDependencies = {
 		// python-rosdep does not exist on Focal, so python3-rosdep is used.
 		// The issue with ros-melodic-desktop-full is also non-applicable.
 		"python3-rosdep",
-		
+
 		// python required for sourcing setup.sh
 		"python",
 	],

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -57,17 +57,6 @@ const distributionSpecificAptDependencies = {
 		// The issue with ros-melodic-desktop-full is also non-applicable.
 		"python3-rosdep",
 	],
-	xenial: [
-		// OpenSplice
-		"libopensplice69",
-
-		// python3-rosdep is conflicting with ros-melodic-desktop-full,
-		// and should not be used here. See ros-tooling/setup-ros#74
-		"python-rosdep",
-
-		// python required for sourcing setup.sh
-		"python",
-	],
 };
 
 /**

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -23,7 +23,6 @@ const aptDependencies: string[] = [
 	"lcov",
 	"libc++-dev",
 	"libc++abi-dev",
-	"python", // required for sourcing setup.sh
 	"python3-catkin-pkg-modules",
 	"python3-pip",
 	"python3-vcstool",

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -46,11 +46,6 @@ const distributionSpecificAptDependencies = {
 		// The issue with ros-melodic-desktop-full is also non-applicable.
 		"python3-rosdep",
 	],
-	jammy: [
-		// python-rosdep does not exist on Jammy, so python3-rosdep is used.
-		// The issue with ros-melodic-desktop-full is also non-applicable.
-		"python3-rosdep",
-	],
 	xenial: [
 		// OpenSplice
 		"libopensplice69",

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -45,7 +45,7 @@ const pip3Packages: string[] = [
 	"mock",
 	"mypy",
 	"nose",
-	"numpy==1.18.0",
+	"numpy",
 	"pep8",
 	"pydocstyle",
 	"pyparsing",

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -108,7 +108,7 @@ export async function runLinux() {
 	fs.writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
 	await utils.exec("sudo", ["apt-key", "add", keyFilePath]);
 
-	const distribCodename = await utils.exec("bash", ["-c", "lsb_release", "-sc"]);
+	const distribCodename = await utils.exec("lsb_release", ["-sc"]);
 	if (distribCodename in distrosRequiringRosUbuntu) {
 		await utils.exec("sudo", [
 			"bash",

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -54,7 +54,6 @@ WE+F5FaIKwb72PL4rLi4
 const distrosRequiringRosUbuntu = [
 	"bionic",
 	"focal",
-	"xenial",
 ];
 
 /**
@@ -157,9 +156,9 @@ export async function runLinux() {
 	await apt.installAptDependencies(installConnext);
 
 	/* Get the latest version of pip before installing dependencies,
-	the version from apt can be very out of date (v8.0 on xenial)
+	the version from apt can be very out of date (v9.0 on bionic)
 	The latest version of pip doesn't support Python3.5 as of v21,
-	but pip 8 doesn't understand the metadata that states this, so we must first
+	but pip 9 doesn't understand the metadata that states this, so we must first
 	make an intermediate upgrade to pip 20, which does understand that information */
 	await pip.runPython3PipInstall(["pip==20.*"]);
 	await pip.runPython3PipInstall(["pip"]);

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -101,11 +101,11 @@ export async function runLinux() {
 	fs.writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
 	await utils.exec("sudo", ["apt-key", "add", keyFilePath]);
 
-	await utils.exec("sudo", [
-		"bash",
-		"-c",
-		`echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`,
-	]);
+// 	await utils.exec("sudo", [
+// 		"bash",
+// 		"-c",
+// 		`echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`,
+// 	]);
 	await utils.exec("sudo", [
 		"bash",
 		"-c",

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -109,11 +109,11 @@ export async function runLinux() {
 	await utils.exec("sudo", ["apt-key", "add", keyFilePath]);
 
 	const distribCodename = await utils.exec("lsb_release", ["-sc"]);
-	if (distribCodename in distrosRequiringRosUbuntu) {
+	if (distrosRequiringRosUbuntu.includes(distribCodename)) {
 		await utils.exec("sudo", [
 			"bash",
 			"-c",
-			`echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`,
+			`echo "deb http://packages.ros.org/ros/ubuntu ${distribCodename} main" > /etc/apt/sources.list.d/ros-latest.list`,
 		]);
 	}
 	await utils.exec("sudo", [
@@ -121,7 +121,7 @@ export async function runLinux() {
 		"-c",
 		`echo "deb http://packages.ros.org/ros2${
 			use_ros2_testing ? "-testing" : ""
-		}/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list`,
+		}/ubuntu ${distribCodename} main" > /etc/apt/sources.list.d/ros2-latest.list`,
 	]);
 
 	await utils.exec("sudo", ["apt-get", "update"]);

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -108,7 +108,7 @@ export async function runLinux() {
 	fs.writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
 	await utils.exec("sudo", ["apt-key", "add", keyFilePath]);
 
-	const distribCodename = await utils.exec("bash", ["lsb_release", "-sc"]);
+	const distribCodename = await utils.exec("bash", ["-c", "lsb_release", "-sc"]);
 	if (distribCodename in distrosRequiringRosUbuntu) {
 		await utils.exec("sudo", [
 			"bash",

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -50,6 +50,13 @@ WE+F5FaIKwb72PL4rLi4
 -----END PGP PUBLIC KEY BLOCK-----
 `;
 
+// List of linux distributions that need http://packages.ros.org/ros/ubuntu APT repo
+const distrosRequiringRosUbuntu = [
+	"bionic",
+	"focal",
+	"xenial",
+];
+
 /**
  * Install ROS 2 on a Linux worker.
  */
@@ -101,11 +108,14 @@ export async function runLinux() {
 	fs.writeFileSync(keyFilePath, openRoboticsAptPublicGpgKey);
 	await utils.exec("sudo", ["apt-key", "add", keyFilePath]);
 
-// 	await utils.exec("sudo", [
-// 		"bash",
-// 		"-c",
-// 		`echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`,
-// 	]);
+	const distribCodename = await utils.exec("bash", ["lsb_release", "-sc"]);
+	if (distribCodename in distrosRequiringRosUbuntu) {
+		await utils.exec("sudo", [
+			"bash",
+			"-c",
+			`echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list`,
+		]);
+	}
 	await utils.exec("sudo", [
 		"bash",
 		"-c",

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -65,16 +65,20 @@ const distrosRequiringRosUbuntu = [
  *
  * @returns Promise<string> Ubuntu distribution codename (e.g. "focal")
  */
-export async function determineDistribCodename(): Promise<string> {
-		let distribCodename = "";
-		const options = {};
-		options.listeners = {
-				stdout: (data) => {
-						distribCodename += data.toString();
-				},
-		};
-		yield utils_exec("bash", ["-c", 'source /etc/lsb-release ; echo -n "$DISTRIB_CODENAME"'], options);
-		return distribCodename;
+ async function determineDistribCodename(): Promise<string> {
+	let distribCodename = "";
+	const options: im.ExecOptions = {};
+	options.listeners = {
+		stdout: (data: Buffer) => {
+			distribCodename += data.toString();
+		},
+	};
+	await utils.exec(
+		"bash",
+		["-c", 'source /etc/lsb-release ; echo -n "$DISTRIB_CODENAME"'],
+		options
+	);
+	return distribCodename;
 }
 
 /**

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -52,8 +52,8 @@ WE+F5FaIKwb72PL4rLi4
 
 // List of linux distributions that need http://packages.ros.org/ros/ubuntu APT repo
 const distrosRequiringRosUbuntu = [
-	"bionic",
-	"focal",
+  "bionic",
+  "focal",
 ];
 
 /**

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -7,10 +7,6 @@ import * as pip from "./package_manager/pip";
 import * as utils from "./utils";
 
 const binaryReleases: { [index: string]: string } = {
-	dashing:
-		"https://github.com/ros2/ros2/releases/download/release-dashing-20210610/ros2-dashing-20210610-windows-amd64.zip",
-	eloquent:
-		"https://github.com/ros2/ros2/releases/download/release-eloquent-20200124/ros2-eloquent-20200124-windows-release-amd64.zip",
 	foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20210902/ros2-foxy-20210902-windows-release-amd64.zip",
 	galactic:
 		"https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-windows-release-amd64.zip",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,12 +42,8 @@ export function getRequiredRosDistributions(): string[] {
 
 //list of valid linux distributions
 const validDistro: string[] = [
-	"kinetic",
-	"lunar",
 	"melodic",
 	"noetic",
-	"dashing",
-	"eloquent",
 	"foxy",
 	"galactic",
 	"rolling",


### PR DESCRIPTION
Issue explained in https://github.com/ros-tooling/action-ros-ci/issues/722#issuecomment-1040337895

This PR covers changes required to get setup-ros working for Ubuntu Jammy:
* Move `"python"` from `aptDependencies` to `distributionSpecificAptDependencies`
as it seems to not be available in Jammy.
* Add `"python3-rosdep"` to `distributionSpecificAptDependencies` of Jammy
* Remove code echoing  `"http://packages.ros.org/ros/ubuntu"` into `/etc/apt/sources.list.d/ros-latest.list`.

**Still Required before merge**:
* Some way of determining whether to use `http://packages.ros.org/ros/ubuntu` or `http://packages.ros.org/ros2/ubuntu` depending on Ubuntu Version or ROS distro. @christophebedard what would be a good way to do this? Happy for you to push changes to the PR if you have a good idea.