### PR TITLE
remove EOL ros distros

### DIFF
--- a/.github/workflows/check-ros2-distribution.sh
+++ b/.github/workflows/check-ros2-distribution.sh
@@ -2,7 +2,7 @@
 #
 # ./check-ros-distribution.sh <ROS distribution>
 # ROS distribution must match the directory name for this distribution
-# in /opt. E.g. dashing
+# in /opt. E.g. galactic
 
 readonly ROS_DISTRIBUTION="$1"
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The workflow `test` is iterating on all ROS 2 distributions, on macOS, and Windo
 The workflow `test_docker` is iterating on all ROS and ROS 2 distributions, for all supported Ubuntu distributions, using Docker.
 The test matrix associates each distribution with one Docker image.
 This is required to ensure that the appropriate Ubuntu container is used.
-For example, Kinetic requires `xenial`, Dashing requires `bionic`, Galactic requires `focal`, etc.
+For example, Melodic requires `bionic`, Galactic requires `focal`, etc.
 
 ```yaml
 jobs:
@@ -195,8 +195,6 @@ jobs:
       matrix:
         os: [macOS-latest, windows-latest]
         ros_distribution: # Only include ROS 2 distributions, as ROS 1 does not support macOS and Windows.
-          - dashing
-          - eloquent
           - foxy
           - galactic
     steps:
@@ -214,11 +212,8 @@ jobs:
     strategy:
       matrix:
         ros_distribution:
-          - kinetic
           - melodic
           - noetic
-          - dashing
-          - eloquent
           - foxy
           - galactic
 
@@ -231,33 +226,18 @@ jobs:
         # https://ros.org/reps/rep-0003.html
         # https://ros.org/reps/rep-2000.html
         include:
-          # Kinetic Kame (May 2016 - May 2021)
-          - docker_image: ubuntu:xenial
-            ros_distribution: kinetic
-            # Setting ros_version is helpful to customize the workflow
-            # depending on whether a ROS 1, or ROS 2 is being tested.
-            # See 'if: ros_version ==' below for an example.
-            ros_version: 1
-
           # Melodic Morenia (May 2018 - May 2023)
           - docker_image: ubuntu:bionic
             ros_distribution: melodic
+            # Setting ros_version is helpful to customize the workflow
+            # depending on whether a ROS 1, or ROS 2 is being tested.
+            # See 'if: ros_version ==' below for an example.
             ros_version: 1
 
           # Noetic Ninjemys (May 2020 - May 2025)
           - docker_image: ubuntu:focal
             ros_distribution: noetic
             ros_version: 1
-
-          # Dashing Diademata (May 2019 - May 2021)
-          - docker_image: ubuntu:bionic
-            ros_distribution: dashing
-            ros_version: 2
-
-          # Eloquent Elusor (November 2019 - November 2020)
-          - docker_image: ubuntu:bionic
-            ros_distribution: eloquent
-            ros_version: 2
 
           # Foxy Fitzroy (June 2020 - May 2023)
           - docker_image: ubuntu:focal

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -54,12 +54,8 @@ describe("required-ros-distributions/melodic workflow tests", () => {
 
 describe("validate distribution test", () => {
 	it("test valid", async () => {
-		await expect(utils.validateDistro(["kinetic"])).toBe(true);
-		await expect(utils.validateDistro(["lunar"])).toBe(true);
 		await expect(utils.validateDistro(["melodic"])).toBe(true);
 		await expect(utils.validateDistro(["noetic"])).toBe(true);
-		await expect(utils.validateDistro(["dashing"])).toBe(true);
-		await expect(utils.validateDistro(["eloquent"])).toBe(true);
 		await expect(utils.validateDistro(["foxy"])).toBe(true);
 		await expect(utils.validateDistro(["galactic"])).toBe(true);
 		await expect(utils.validateDistro(["rolling"])).toBe(true);
@@ -76,10 +72,14 @@ describe("validate distribution test", () => {
 		await expect(utils.validateDistro(["hydro"])).toBe(false);
 		await expect(utils.validateDistro(["indigo"])).toBe(false);
 		await expect(utils.validateDistro(["jade"])).toBe(false);
+		await expect(utils.validateDistro(["kinetic"])).toBe(false);
+		await expect(utils.validateDistro(["lunar"])).toBe(false);
 		//ROS2 End-of-Life
 		await expect(utils.validateDistro(["ardent"])).toBe(false);
 		await expect(utils.validateDistro(["bouncy"])).toBe(false);
 		await expect(utils.validateDistro(["crystal"])).toBe(false);
+		await expect(utils.validateDistro(["dashing"])).toBe(false);
+		await expect(utils.validateDistro(["eloquent"])).toBe(false);
 		// Does not exist or not all valid
 		await expect(utils.validateDistro(["foxy", "doesntexist"])).toBe(false);
 		await expect(utils.validateDistro(["master"])).toBe(false);

--- a/action.yml
+++ b/action.yml
@@ -26,17 +26,14 @@ inputs:
 
       Allowed ROS distributions
       - "" (no value) - no ROS binary installation
-      - kinetic
       - melodic
       - noetic
-      - dashing
-      - eloquent
       - foxy
       - galactic
       - rolling
 
       Multiple values can be passed using a whitespace delimited list
-      "melodic dashing".
+      "noetic galactic".
     required: false
     default: ""
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -6004,12 +6004,8 @@ function getRequiredRosDistributions() {
 }
 //list of valid linux distributions
 const validDistro = [
-    "kinetic",
-    "lunar",
     "melodic",
     "noetic",
-    "dashing",
-    "eloquent",
     "foxy",
     "galactic",
     "rolling",
@@ -6076,13 +6072,6 @@ const distributionSpecificAptDependencies = {
         // python-rosdep does not exist on Focal, so python3-rosdep is used.
         // The issue with ros-melodic-desktop-full is also non-applicable.
         "python3-rosdep",
-    ],
-    xenial: [
-        // OpenSplice
-        "libopensplice69",
-        // python3-rosdep is conflicting with ros-melodic-desktop-full,
-        // and should not be used here. See ros-tooling/setup-ros#74
-        "python-rosdep",
     ],
 };
 /**
@@ -6198,7 +6187,7 @@ const pip3Packages = [
     "mock",
     "mypy",
     "nose",
-    "numpy==1.18.0",
+    "numpy",
     "pep8",
     "pydocstyle",
     "pyparsing",
@@ -6371,9 +6360,9 @@ function runLinux() {
         // they are also installed during this stage.
         yield installAptDependencies(installConnext);
         /* Get the latest version of pip before installing dependencies,
-        the version from apt can be very out of date (v8.0 on xenial)
+        the version from apt can be very out of date (v9.0 on bionic)
         The latest version of pip doesn't support Python3.5 as of v21,
-        but pip 8 doesn't understand the metadata that states this, so we must first
+        but pip 9 doesn't understand the metadata that states this, so we must first
         make an intermediate upgrade to pip 20, which does understand that information */
         yield runPython3PipInstall(["pip==20.*"]);
         yield runPython3PipInstall(["pip"]);
@@ -6593,8 +6582,6 @@ var setup_ros_windows_awaiter = (undefined && undefined.__awaiter) || function (
 
 
 const binaryReleases = {
-    dashing: "https://github.com/ros2/ros2/releases/download/release-dashing-20210610/ros2-dashing-20210610-windows-amd64.zip",
-    eloquent: "https://github.com/ros2/ros2/releases/download/release-eloquent-20200124/ros2-eloquent-20200124-windows-release-amd64.zip",
     foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20210902/ros2-foxy-20210902-windows-release-amd64.zip",
     galactic: "https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-windows-release-amd64.zip",
 };

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -47,14 +47,6 @@ const distributionSpecificAptDependencies = {
 		// The issue with ros-melodic-desktop-full is also non-applicable.
 		"python3-rosdep",
 	],
-	xenial: [
-		// OpenSplice
-		"libopensplice69",
-
-		// python3-rosdep is conflicting with ros-melodic-desktop-full,
-		// and should not be used here. See ros-tooling/setup-ros#74
-		"python-rosdep",
-	],
 };
 
 /**

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -45,7 +45,7 @@ const pip3Packages: string[] = [
 	"mock",
 	"mypy",
 	"nose",
-	"numpy==1.18.0",
+	"numpy",
 	"pep8",
 	"pydocstyle",
 	"pyparsing",

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -123,9 +123,9 @@ export async function runLinux() {
 	await apt.installAptDependencies(installConnext);
 
 	/* Get the latest version of pip before installing dependencies,
-	the version from apt can be very out of date (v8.0 on xenial)
+	the version from apt can be very out of date (v9.0 on bionic)
 	The latest version of pip doesn't support Python3.5 as of v21,
-	but pip 8 doesn't understand the metadata that states this, so we must first
+	but pip 9 doesn't understand the metadata that states this, so we must first
 	make an intermediate upgrade to pip 20, which does understand that information */
 	await pip.runPython3PipInstall(["pip==20.*"]);
 	await pip.runPython3PipInstall(["pip"]);

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -7,10 +7,6 @@ import * as pip from "./package_manager/pip";
 import * as utils from "./utils";
 
 const binaryReleases: { [index: string]: string } = {
-	dashing:
-		"https://github.com/ros2/ros2/releases/download/release-dashing-20210610/ros2-dashing-20210610-windows-amd64.zip",
-	eloquent:
-		"https://github.com/ros2/ros2/releases/download/release-eloquent-20200124/ros2-eloquent-20200124-windows-release-amd64.zip",
 	foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20210902/ros2-foxy-20210902-windows-release-amd64.zip",
 	galactic:
 		"https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-windows-release-amd64.zip",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,12 +42,8 @@ export function getRequiredRosDistributions(): string[] {
 
 //list of valid linux distributions
 const validDistro: string[] = [
-	"kinetic",
-	"lunar",
 	"melodic",
 	"noetic",
-	"dashing",
-	"eloquent",
 	"foxy",
 	"galactic",
 	"rolling",


### PR DESCRIPTION
Removes EOL ros distros from all scripts. This helps in transitioning to ROS2 Jammy.

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>