### PR TITLE
Add support for Humble

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,8 @@ jobs:
       - uses: ./ # Uses an action in the root directory
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
+          # TODO remove this once Humble has been officially released
+          use-ros2-testing: ${{ matrix.ros_distribution == 'humble' && 'true' || '' }}
       - run: .github/workflows/check-environment.sh
       - run: .github/workflows/check-ros-distribution.sh "${{ matrix.ros_distribution }}"
         if: matrix.ros_version == 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,8 @@ jobs:
           # Galactic Geochelone (May 2021 - November 2022)
           - galactic
           # Humble Hawksbill (May 2022 - May 2027)
-          - humble
+          # TODO uncomment this once Humble is officially available on Windows
+          # - humble
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,8 @@ jobs:
           - foxy
           # Galactic Geochelone (May 2021 - November 2022)
           - galactic
+          # Humble Hawksbill (May 2022 - May 2027)
+          - humble
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.1.1
@@ -100,6 +102,7 @@ jobs:
           - noetic
           - foxy
           - galactic
+          - humble
           - rolling
 
         # Define the Docker image(s) associated with each ROS distribution.
@@ -129,8 +132,13 @@ jobs:
             ros_distribution: galactic
             ros_version: 2
 
+          # Humble Hawksbill (May 2022 - May 2027)
+          - docker_image: ubuntu:jammy
+            ros_distribution: humble
+            ros_version: 2
+
           # Rolling Ridley (see REP 2002: https://www.ros.org/reps/rep-2002.html)
-          - docker_image: ubuntu:focal
+          - docker_image: ubuntu:jammy
             ros_distribution: rolling
             ros_version: 2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
           # TODO remove this once Humble has been officially released
-          use-ros2-testing: ${{ matrix.ros_distribution == 'humble' && 'true' || '' }}
+          use-ros2-testing: ${{ matrix.ros_distribution == 'humble' }}
       - run: .github/workflows/check-environment.sh
       - run: .github/workflows/check-ros-distribution.sh "${{ matrix.ros_distribution }}"
         if: matrix.ros_version == 1

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ jobs:
         ros_distribution: # Only include ROS 2 distributions, as ROS 1 does not support macOS and Windows.
           - foxy
           - galactic
+          - humble
     steps:
       - uses: ros-tooling/setup-ros@v0.3
         with:
@@ -216,6 +217,7 @@ jobs:
           - noetic
           - foxy
           - galactic
+          - humble
 
         # Define the Docker image(s) associated with each ROS distribution.
         # The include syntax allows additional variables to be defined, like
@@ -247,6 +249,11 @@ jobs:
           # Galactic Geochelone (May 2021 - November 2022)
           - docker_image: ubuntu:focal
             ros_distribution: galactic
+            ros_version: 2
+
+          # Humble Hawksbill (May 2022 - May 2027)
+          - docker_image: ubuntu:jammy
+            ros_distribution: humble
             ros_version: 2
 
           # Rolling Ridley (No End-Of-Life)

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -58,6 +58,7 @@ describe("validate distribution test", () => {
 		await expect(utils.validateDistro(["noetic"])).toBe(true);
 		await expect(utils.validateDistro(["foxy"])).toBe(true);
 		await expect(utils.validateDistro(["galactic"])).toBe(true);
+		await expect(utils.validateDistro(["humble"])).toBe(true);
 		await expect(utils.validateDistro(["rolling"])).toBe(true);
 	});
 

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,7 @@ inputs:
       - noetic
       - foxy
       - galactic
+      - humble
       - rolling
 
       Multiple values can be passed using a whitespace delimited list

--- a/dist/index.js
+++ b/dist/index.js
@@ -6008,6 +6008,7 @@ const validDistro = [
     "noetic",
     "foxy",
     "galactic",
+    "humble",
     "rolling",
 ];
 //Determine whether all inputs name supported ROS distributions.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,7 @@ const validDistro: string[] = [
 	"noetic",
 	"foxy",
 	"galactic",
+	"humble",
 	"rolling",
 ];
 


### PR DESCRIPTION
Closes #483

This adds support for Humble by adding it to the list of valid distros. I've updated the tests.

I updated part of the README, but I didn't update all examples since Humble has not yet been officially released, so users need to use the testing repository.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>