### PR TITLE
Make Connext version distro-specific

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,11 @@ jobs:
 
   test_install_connext:
     name: "Test with RTI Connext DDS"
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,3 +208,18 @@ jobs:
           node-version: "12.x"
       - run: .github/workflows/build-and-test.sh
       - uses: ./
+
+  test_install_connext:
+    name: "Test with RTI Connext DDS"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.1.1
+        with:
+          node-version: "12.x"
+      - run: .github/workflows/build-and-test.sh
+      - uses: ./
+        with:
+          install-connext: true
+      - run: .github/workflows/check-environment.sh
+      - run: dpkg -l | grep rti-connext-dds-

--- a/dist/index.js
+++ b/dist/index.js
@@ -6053,7 +6053,6 @@ var apt_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argu
     });
 };
 
-const CONNEXT_APT_PACKAGE_NAME = "rti-connext-dds-5.3.1"; // RTI Connext
 const aptCommandLine = [
     "DEBIAN_FRONTEND=noninteractive",
     "RTI_NC_LICENSE_ACCEPTED=yes",
@@ -6104,6 +6103,11 @@ const distributionSpecificAptDependencies = {
         "python3-rosdep",
     ],
 };
+const aptRtiConnextDds = {
+    bionic: "rti-connext-dds-5.3.1",
+    focal: "rti-connext-dds-5.3.1",
+    jammy: "rti-connext-dds-6.0.1",
+};
 /**
  * Run apt-get install on list of specified packages.
  *
@@ -6129,10 +6133,10 @@ function runAptGetInstall(packages) {
  */
 function installAptDependencies(installConnext = false) {
     return apt_awaiter(this, void 0, void 0, function* () {
-        let aptPackages = installConnext
-            ? aptDependencies.concat(CONNEXT_APT_PACKAGE_NAME)
-            : aptDependencies;
         const distribCodename = yield determineDistribCodename();
+        let aptPackages = installConnext
+            ? aptDependencies.concat(aptRtiConnextDds[distribCodename] || [])
+            : aptDependencies;
         const additionalAptPackages = distributionSpecificAptDependencies[distribCodename] || [];
         aptPackages = aptPackages.concat(additionalAptPackages);
         return runAptGetInstall(aptPackages);

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -1,7 +1,5 @@
 import * as utils from "../utils";
 
-const CONNEXT_APT_PACKAGE_NAME = "rti-connext-dds-5.3.1"; // RTI Connext
-
 const aptCommandLine: string[] = [
 	"DEBIAN_FRONTEND=noninteractive",
 	"RTI_NC_LICENSE_ACCEPTED=yes",
@@ -56,6 +54,12 @@ const distributionSpecificAptDependencies = {
 	],
 };
 
+const aptRtiConnextDds = {
+	bionic: "rti-connext-dds-5.3.1",
+	focal: "rti-connext-dds-5.3.1",
+	jammy: "rti-connext-dds-6.0.1",
+};
+
 /**
  * Run apt-get install on list of specified packages.
  *
@@ -81,10 +85,10 @@ export async function runAptGetInstall(packages: string[]): Promise<number> {
 export async function installAptDependencies(
 	installConnext = false
 ): Promise<number> {
-	let aptPackages: string[] = installConnext
-		? aptDependencies.concat(CONNEXT_APT_PACKAGE_NAME)
-		: aptDependencies;
 	const distribCodename = await utils.determineDistribCodename();
+	let aptPackages: string[] = installConnext
+		? aptDependencies.concat(aptRtiConnextDds[distribCodename] || [])
+		: aptDependencies;
 	const additionalAptPackages =
 		distributionSpecificAptDependencies[distribCodename] || [];
 	aptPackages = aptPackages.concat(additionalAptPackages);


### PR DESCRIPTION
We didn't make the Connext version distro-specific. The version was bumped to 6.0.1 for Jammy. We don't have any tests that use `install-connext: true`, so we never caught it.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>