### PR TITLE
Add support for Humble on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,7 @@ jobs:
           # Galactic Geochelone (May 2021 - November 2022)
           - galactic
           # Humble Hawksbill (May 2022 - May 2027)
-          # TODO uncomment this once Humble is officially available on Windows
-          # - humble
+          - humble
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.2.0

--- a/dist/index.js
+++ b/dist/index.js
@@ -6602,6 +6602,7 @@ var setup_ros_windows_awaiter = (undefined && undefined.__awaiter) || function (
 const binaryReleases = {
     foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20210902/ros2-foxy-20210902-windows-release-amd64.zip",
     galactic: "https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-windows-release-amd64.zip",
+    humble: "https://github.com/ros2/ros2/releases/download/release-humble-20220523/ros2-humble-20220523-windows-release-amd64.zip",
 };
 const setup_ros_windows_pip3Packages = ["lxml", "netifaces"];
 /**

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -10,6 +10,8 @@ const binaryReleases: { [index: string]: string } = {
 	foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20210902/ros2-foxy-20210902-windows-release-amd64.zip",
 	galactic:
 		"https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-windows-release-amd64.zip",
+	humble:
+		"https://github.com/ros2/ros2/releases/download/release-humble-20220523/ros2-humble-20220523-windows-release-amd64.zip",
 };
 
 const pip3Packages: string[] = ["lxml", "netifaces"];


### PR DESCRIPTION
Relates to https://github.com/ros-tooling/setup-ros/issues/483

See release: https://github.com/ros2/ros2/releases/tag/release-humble-20220523

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>