### PR TITLE
Sync Windows choco dependencies with ROS 2 CI

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6520,23 +6520,20 @@ const chocoCommandLine = [
     "--no-progress",
     "--yes",
 ];
-const chocoDependencies = [
-    "cppcheck",
-    "wget",
-    "7zip",
-    "lcov",
-    "openssl",
-];
+const chocoDependencies = ["wget", "7zip", "lcov", "openssl"];
+const chocoDependenciesPinned = [["cppcheck", "1.90"]];
 const ros2ChocolateyPackagesUrl = [
-    "https://github.com/ros2/choco-packages/releases/download/2019-10-24/asio.1.12.1.nupkg",
-    "https://github.com/ros2/choco-packages/releases/download/2019-10-24/cunit.2.1.3.nupkg",
-    "https://github.com/ros2/choco-packages/releases/download/2019-10-24/eigen.3.3.4.nupkg",
-    "https://github.com/ros2/choco-packages/releases/download/2019-10-24/log4cxx.0.10.0-2.nupkg",
-    "https://github.com/ros2/choco-packages/releases/download/2019-10-24/tinyxml-usestl.2.6.2.nupkg",
-    "https://github.com/ros2/choco-packages/releases/download/2019-10-24/tinyxml2.6.0.0.nupkg",
+    "https://github.com/ros2/choco-packages/releases/download/2022-03-15/asio.1.12.1.nupkg",
+    "https://github.com/ros2/choco-packages/releases/download/2022-03-15/bullet.3.17.nupkg",
+    "https://github.com/ros2/choco-packages/releases/download/2022-03-15/cunit.2.1.3.nupkg",
+    "https://github.com/ros2/choco-packages/releases/download/2022-03-15/eigen.3.3.4.nupkg",
+    "https://github.com/ros2/choco-packages/releases/download/2022-03-15/log4cxx.0.10.0.nupkg",
+    "https://github.com/ros2/choco-packages/releases/download/2022-03-15/tinyxml-usestl.2.6.2.nupkg",
+    "https://github.com/ros2/choco-packages/releases/download/2022-03-15/tinyxml2.6.0.0.nupkg",
 ];
 const ros2ChocolateyPackages = [
     "asio",
+    "bullet",
     "cunit",
     "eigen",
     "log4cxx",
@@ -6555,13 +6552,29 @@ function runChocoInstall(packages) {
     });
 }
 /**
+ * Run choco install on the list of specified packages and versions.
+ *
+ * @param   packages        list of Chocolatey pacakges to be installed along with their versions
+ * @returns Promise<number> exit code
+ */
+function runChocoInstallVersion(packages) {
+    return chocolatey_awaiter(this, void 0, void 0, function* () {
+        let ret = 0;
+        for (const [pkg, version] of packages) {
+            ret += yield utils_exec("choco", chocoCommandLine.concat(pkg, "--version", version));
+        }
+        return ret !== 0 ? 1 : 0;
+    });
+}
+/**
  * Install ROS 2 Chocolatey dependencies.
  *
  * @returns Promise<number> exit code
  */
 function installChocoDependencies() {
     return chocolatey_awaiter(this, void 0, void 0, function* () {
-        return runChocoInstall(chocoDependencies);
+        return ((yield runChocoInstall(chocoDependencies)) +
+            (yield runChocoInstallVersion(chocoDependenciesPinned)));
     });
 }
 /**

--- a/src/package_manager/chocolatey.ts
+++ b/src/package_manager/chocolatey.ts
@@ -7,24 +7,22 @@ const chocoCommandLine: string[] = [
 	"--yes",
 ];
 
-const chocoDependencies: string[] = [
-	"cppcheck",
-	"wget",
-	"7zip",
-	"lcov",
-	"openssl",
-];
+const chocoDependencies: string[] = ["wget", "7zip", "lcov", "openssl"];
+
+const chocoDependenciesPinned: [string, string][] = [["cppcheck", "1.90"]];
 
 const ros2ChocolateyPackagesUrl: string[] = [
-	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/asio.1.12.1.nupkg",
-	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/cunit.2.1.3.nupkg",
-	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/eigen.3.3.4.nupkg",
-	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/log4cxx.0.10.0-2.nupkg",
-	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/tinyxml-usestl.2.6.2.nupkg",
-	"https://github.com/ros2/choco-packages/releases/download/2019-10-24/tinyxml2.6.0.0.nupkg",
+	"https://github.com/ros2/choco-packages/releases/download/2022-03-15/asio.1.12.1.nupkg",
+	"https://github.com/ros2/choco-packages/releases/download/2022-03-15/bullet.3.17.nupkg",
+	"https://github.com/ros2/choco-packages/releases/download/2022-03-15/cunit.2.1.3.nupkg",
+	"https://github.com/ros2/choco-packages/releases/download/2022-03-15/eigen.3.3.4.nupkg",
+	"https://github.com/ros2/choco-packages/releases/download/2022-03-15/log4cxx.0.10.0.nupkg",
+	"https://github.com/ros2/choco-packages/releases/download/2022-03-15/tinyxml-usestl.2.6.2.nupkg",
+	"https://github.com/ros2/choco-packages/releases/download/2022-03-15/tinyxml2.6.0.0.nupkg",
 ];
 const ros2ChocolateyPackages: string[] = [
 	"asio",
+	"bullet",
 	"cunit",
 	"eigen",
 	"log4cxx",
@@ -43,12 +41,34 @@ export async function runChocoInstall(packages: string[]): Promise<number> {
 }
 
 /**
+ * Run choco install on the list of specified packages and versions.
+ *
+ * @param   packages        list of Chocolatey pacakges to be installed along with their versions
+ * @returns Promise<number> exit code
+ */
+export async function runChocoInstallVersion(
+	packages: [string, string][]
+): Promise<number> {
+	let ret = 0;
+	for (const [pkg, version] of packages) {
+		ret += await utils.exec(
+			"choco",
+			chocoCommandLine.concat(pkg, "--version", version)
+		);
+	}
+	return ret !== 0 ? 1 : 0;
+}
+
+/**
  * Install ROS 2 Chocolatey dependencies.
  *
  * @returns Promise<number> exit code
  */
 export async function installChocoDependencies(): Promise<number> {
-	return runChocoInstall(chocoDependencies);
+	return (
+		(await runChocoInstall(chocoDependencies)) +
+		(await runChocoInstallVersion(chocoDependenciesPinned))
+	);
 }
 
 /**


### PR DESCRIPTION
Fixes #491

This changes the Windows dependencies installation to more closely match how it is done for ci.ros2.org: https://github.com/ros-infrastructure/ros2-cookbooks/blob/de9d4cc159f2c4402e4636c458ad4bc535d0610d/cookbooks/ros2_windows/recipes/chocolatey_installs.rb

* Update provided choco packages to 2022-03-15
* Pin cppcheck to 1.90, which addresses #491

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>