### PR TITLE
Add `pyopenssl` to list of pip3 dependencies

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8122,6 +8122,7 @@ const pip3Packages = [
     "numpy",
     "pep8",
     "pydocstyle",
+    "pyopenssl",
     "pyparsing",
     "pytest",
     "pytest-cov",

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -48,6 +48,7 @@ const pip3Packages: string[] = [
 	"numpy",
 	"pep8",
 	"pydocstyle",
+	"pyopenssl",
 	"pyparsing",
 	"pytest",
 	"pytest-cov",


### PR DESCRIPTION
Fixes #515

Unfortunately I did not have time to test this