### PR TITLE
add python3-rosinstall-generator as dependency

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7988,6 +7988,7 @@ const aptDependencies = [
     "lcov",
     "python3-catkin-pkg-modules",
     "python3-pip",
+    "python3-rosinstall-generator",
     "python3-vcstool",
     "wget",
     // FastRTPS dependencies

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -20,6 +20,7 @@ const aptDependencies: string[] = [
 	"lcov",
 	"python3-catkin-pkg-modules",
 	"python3-pip",
+	"python3-rosinstall-generator",
 	"python3-vcstool",
 	"wget",
 	// FastRTPS dependencies


### PR DESCRIPTION
Resolves: https://github.com/ros-tooling/setup-ros/issues/529