### PR TITLE
Fix ``husky: not found``

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,9 +2,10 @@
 
 ## Prerequisites
 
-Install [Node.js](https://nodejs.org/en/download/).
+* Install [Node.js](https://nodejs.org/en/download/).
+  We are currently using Node.js v12.
 
-We are currently using Node.js v12.
+* Install [husky](https://www.npmjs.com/package/husky) (``npm install husky``)
 
 ## Setup git hooks
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,10 +2,15 @@
 
 ## Prerequisites
 
-* Install [Node.js](https://nodejs.org/en/download/).
-  We are currently using Node.js v12.
+Install [Node.js](https://nodejs.org/en/download/).
 
-* Install [husky](https://www.npmjs.com/package/husky) (``npm install husky``)
+We are currently using Node.js v12.
+
+## Install Dependencies
+
+```sh
+npm install
+```
 
 ## Setup git hooks
 
@@ -18,8 +23,6 @@ npm run prepare
 ## Build and test
 
 ```sh
-# install dependencies
-npm install
 # autoformat sources to meet enforced linter style
 npm run fixup
 # generate build artifacts (run automatically when committing if git hooks are installed)


### PR DESCRIPTION
Currently, running ``npm run prepare`` results in the following output:

```sh
> setup-ros@0.4.2 prepare
> husky install

sh: 1: husky: not found
```

as husky is not installed.