### PR TITLE
Remove Galactic since it is EOL

### DIFF
--- a/.github/workflows/check-ros2-distribution.sh
+++ b/.github/workflows/check-ros2-distribution.sh
@@ -2,7 +2,7 @@
 #
 # ./check-ros-distribution.sh <ROS distribution>
 # ROS distribution must match the directory name for this distribution
-# in /opt. E.g. galactic
+# in /opt. E.g. humble
 
 readonly ROS_DISTRIBUTION="$1"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,6 @@ jobs:
         ros_distribution:
           # Foxy Fitzroy (June 2020 - May 2023)
           - foxy
-          # Galactic Geochelone (May 2021 - November 2022)
-          - galactic
           # Humble Hawksbill (May 2022 - May 2027)
           - humble
     steps:
@@ -101,7 +99,6 @@ jobs:
           - melodic
           - noetic
           - foxy
-          - galactic
           - humble
           - rolling
 
@@ -125,11 +122,6 @@ jobs:
           # Foxy Fitzroy (June 2020 - May 2023)
           - docker_image: ubuntu:focal
             ros_distribution: foxy
-            ros_version: 2
-
-          # Galactic Geochelone (May 2021 - November 2022)
-          - docker_image: ubuntu:focal
-            ros_distribution: galactic
             ros_version: 2
 
           # Humble Hawksbill (May 2022 - May 2027)
@@ -174,8 +166,8 @@ jobs:
       - run: .github/workflows/build-and-test.sh
       - uses: ./ # Uses an action in the root directory
         with:
-          required-ros-distributions: noetic galactic
-      - run: .github/workflows/check-ros2-distribution.sh galactic
+          required-ros-distributions: noetic foxy
+      - run: .github/workflows/check-ros2-distribution.sh foxy
       - run: .github/workflows/check-ros-distribution.sh noetic
 
   test_repo_with_root_setup_cfg:

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The workflow `test` is iterating on all ROS 2 distributions, on macOS, and Windo
 The workflow `test_docker` is iterating on all ROS and ROS 2 distributions, for all supported Ubuntu distributions, using Docker.
 The test matrix associates each distribution with one Docker image.
 This is required to ensure that the appropriate Ubuntu container is used.
-For example, Melodic requires `bionic`, Galactic requires `focal`, Humble requires `jammy`, etc.
+For example, Melodic requires `bionic`, Humble requires `jammy`, etc.
 
 ```yaml
 jobs:
@@ -196,7 +196,6 @@ jobs:
         os: [macOS-latest, windows-latest]
         ros_distribution: # Only include ROS 2 distributions, as ROS 1 does not support macOS and Windows.
           - foxy
-          - galactic
           - humble
     steps:
       - uses: ros-tooling/setup-ros@v0.5
@@ -216,7 +215,6 @@ jobs:
           - melodic
           - noetic
           - foxy
-          - galactic
           - humble
 
         # Define the Docker image(s) associated with each ROS distribution.
@@ -244,11 +242,6 @@ jobs:
           # Foxy Fitzroy (June 2020 - May 2023)
           - docker_image: ubuntu:focal
             ros_distribution: foxy
-            ros_version: 2
-
-          # Galactic Geochelone (May 2021 - November 2022)
-          - docker_image: ubuntu:focal
-            ros_distribution: galactic
             ros_version: 2
 
           # Humble Hawksbill (May 2022 - May 2027)

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -57,7 +57,6 @@ describe("validate distribution test", () => {
 		await expect(utils.validateDistro(["melodic"])).toBe(true);
 		await expect(utils.validateDistro(["noetic"])).toBe(true);
 		await expect(utils.validateDistro(["foxy"])).toBe(true);
-		await expect(utils.validateDistro(["galactic"])).toBe(true);
 		await expect(utils.validateDistro(["humble"])).toBe(true);
 		await expect(utils.validateDistro(["rolling"])).toBe(true);
 	});
@@ -81,6 +80,7 @@ describe("validate distribution test", () => {
 		await expect(utils.validateDistro(["crystal"])).toBe(false);
 		await expect(utils.validateDistro(["dashing"])).toBe(false);
 		await expect(utils.validateDistro(["eloquent"])).toBe(false);
+		await expect(utils.validateDistro(["galactic"])).toBe(false);
 		// Does not exist or not all valid
 		await expect(utils.validateDistro(["foxy", "doesntexist"])).toBe(false);
 		await expect(utils.validateDistro(["master"])).toBe(false);

--- a/action.yml
+++ b/action.yml
@@ -29,12 +29,11 @@ inputs:
       - melodic
       - noetic
       - foxy
-      - galactic
       - humble
       - rolling
 
       Multiple values can be passed using a whitespace delimited list
-      "noetic galactic".
+      "noetic humble".
     required: false
     default: ""
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -7923,7 +7923,6 @@ const validDistro = [
     "melodic",
     "noetic",
     "foxy",
-    "galactic",
     "humble",
     "rolling",
 ];
@@ -8537,7 +8536,6 @@ var setup_ros_windows_awaiter = (undefined && undefined.__awaiter) || function (
 
 const binaryReleases = {
     foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20210902/ros2-foxy-20210902-windows-release-amd64.zip",
-    galactic: "https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-windows-release-amd64.zip",
     humble: "https://github.com/ros2/ros2/releases/download/release-humble-20220523/ros2-humble-20220523-windows-release-amd64.zip",
 };
 const setup_ros_windows_pip3Packages = ["lxml", "netifaces"];

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -8,8 +8,6 @@ import * as utils from "./utils";
 
 const binaryReleases: { [index: string]: string } = {
 	foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20210902/ros2-foxy-20210902-windows-release-amd64.zip",
-	galactic:
-		"https://github.com/ros2/ros2/releases/download/release-galactic-20210716/ros2-galactic-20210616-windows-release-amd64.zip",
 	humble:
 		"https://github.com/ros2/ros2/releases/download/release-humble-20220523/ros2-humble-20220523-windows-release-amd64.zip",
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,7 +45,6 @@ const validDistro: string[] = [
 	"melodic",
 	"noetic",
 	"foxy",
-	"galactic",
 	"humble",
 	"rolling",
 ];


### PR DESCRIPTION
Support for Galactic ended after November 2022.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>