### PR TITLE
Temporarily work around apt error with grub-efi-amd64-signed

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7190,6 +7190,8 @@ function runLinux() {
             `echo "deb http://packages.ros.org/ros2${use_ros2_testing ? "-testing" : ""}/ubuntu ${distribCodename} main" > /etc/apt/sources.list.d/ros2-latest.list`,
         ]);
         yield utils.exec("sudo", ["apt-get", "update"]);
+        // Temporary fix to avoid error mount: /var/lib/grub/esp: special device (...) does not exist.
+        yield utils.exec("sudo", ["apt-mark", "hold", "grub-efi-amd64-signed"]);
         yield utils.exec("sudo", ["apt-get", "upgrade", "-y"]);
         // Install rosdep and vcs, as well as FastRTPS dependencies, OpenSplice, and
         // optionally RTI Connext.

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -121,6 +121,8 @@ export async function runLinux() {
 	]);
 
 	await utils.exec("sudo", ["apt-get", "update"]);
+	// Temporary fix to avoid error mount: /var/lib/grub/esp: special device (...) does not exist.
+	await utils.exec("sudo", ["apt-mark", "hold", "grub-efi-amd64-signed"]);
 	await utils.exec("sudo", ["apt-get", "upgrade", "-y"]);
 
 	// Install rosdep and vcs, as well as FastRTPS dependencies, OpenSplice, and


### PR DESCRIPTION
This action is currently broken. It gets stuck with this error:

```
Invoking "sudo apt-get upgrade -y"
  /usr/bin/sudo apt-get upgrade -y
  Reading package lists...
  Building dependency tree...
  Reading state information...
  Calculating upgrade...
  The following packages have been kept back:
    dotnet-runtime-6.0
  The following packages will be upgraded:
    aspnetcore-runtime-6.0 aspnetcore-targeting-pack-6.0 dotnet-apphost-pack-6.0
    dotnet-hostfxr-6.0 dotnet-sdk-7.0 dotnet-targeting-pack-6.0 firefox
    grub-efi-amd64-bin grub-efi-amd64-signed netstandard-targeting-pack-2.1
    powershell
  11 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
  Need to get 184 MB of archives.
(...)
  Setting up grub-efi-amd64-bin (2.06-2ubuntu14.1) ...
  Setting up grub-efi-amd64-signed (1.187.3~22.04.1+2.06-2ubuntu14.1) ...
  mount: /var/lib/grub/esp: special device /dev/disk/by-id/scsi-14d534654202020200690df035523a242afc173af9e57f2a4-part15 does not exist.
  dpkg: error processing package grub-efi-amd64-signed (--configure):
   installed grub-efi-amd64-signed package post-installation script subprocess returned error exit status 32
  Processing triggers for mailcap (3.70+nmu1ubuntu1) ...
  Processing triggers for hicolor-icon-theme (0.17-2) ...
  Processing triggers for man-db (2.10.2-1) ...
  Errors were encountered while processing:
   grub-efi-amd64-signed
  needrestart is being skipped since dpkg has failed
  E: Sub-process /usr/bin/dpkg returned an error code (1)
Error: The process '/usr/bin/sudo' failed with exit code 100
```

This is clearly just a workaround and needs an upstream fix from Ubuntu, but with this change the action is usable again.