### PR TITLE
Update to latest binary ros2 windows distributions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7348,8 +7348,8 @@ const chocolatey = __importStar(__nccwpck_require__(855));
 const pip = __importStar(__nccwpck_require__(6744));
 const utils = __importStar(__nccwpck_require__(1314));
 const binaryReleases = {
-    foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20210902/ros2-foxy-20210902-windows-release-amd64.zip",
-    humble: "https://github.com/ros2/ros2/releases/download/release-humble-20220523/ros2-humble-20220523-windows-release-amd64.zip",
+    foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20221021/ros2-foxy-20221021-windows-release-amd64.zip",
+    humble: "https://github.com/ros2/ros2/releases/download/release-humble-20230213/ros2-humble-20230127-windows-release-amd64.zip",
 };
 const pip3Packages = ["lxml", "netifaces"];
 /**

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -7,9 +7,9 @@ import * as pip from "./package_manager/pip";
 import * as utils from "./utils";
 
 const binaryReleases: { [index: string]: string } = {
-	foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20210902/ros2-foxy-20210902-windows-release-amd64.zip",
+	foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20221021/ros2-foxy-20221021-windows-release-amd64.zip",
 	humble:
-		"https://github.com/ros2/ros2/releases/download/release-humble-20220523/ros2-humble-20220523-windows-release-amd64.zip",
+		"https://github.com/ros2/ros2/releases/download/release-humble-20230213/ros2-humble-20230127-windows-release-amd64.zip",
 };
 
 const pip3Packages: string[] = ["lxml", "netifaces"];


### PR DESCRIPTION
This updates to the latest windows binary distributions like this PR did: https://github.com/ros-tooling/setup-ros/pull/450

Doing this manually since https://github.com/ros-tooling/setup-ros/issues/453 isn't resolved yet.

Came across this when debugging the CI failure for this `ros2_dotnet` PR: https://github.com/ros2-dotnet/ros2_dotnet/pull/90#issuecomment-1314201102
- The newest github windows runner images include newer versions of CMake that are not compatible with the version of ament_cmake (0.9.9) that is included in the old binary release specified in `setup-ros`.
- https://github.com/ament/ament_cmake/pull/395 is in ament_cmake v0.9.11 that should be included in the newest foxy binary release.
- Tested this by using my feature branch as temporary commit in my `ros2_dotnet` PR, though there only foxy is used currently.
