### PR TITLE
Drop support for EOL distros and Ubuntu Bionic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,6 @@ jobs:
           # - macOS-latest
           - windows-latest
         ros_distribution:
-          # Foxy Fitzroy (June 2020 - May 2023)
-          - foxy
           # Humble Hawksbill (May 2022 - May 2027)
           - humble
           # Iron Irwini (May 2023 - November 2024)
@@ -97,9 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         ros_distribution:
-          - melodic
           - noetic
-          - foxy
           - humble
           - iron
           - rolling
@@ -111,20 +107,10 @@ jobs:
         #
         # Platforms are defined in REP 3: https://ros.org/reps/rep-0003.html
         include:
-          # Melodic Morenia (May 2018 - May 2023)
-          - docker_image: ubuntu:bionic
-            ros_distribution: melodic
-            ros_version: 1
-
           # Noetic Ninjemys (May 2020 - May 2025)
           - docker_image: ubuntu:focal
             ros_distribution: noetic
             ros_version: 1
-
-          # Foxy Fitzroy (June 2020 - May 2023)
-          - docker_image: ubuntu:focal
-            ros_distribution: foxy
-            ros_version: 2
 
           # Humble Hawksbill (May 2022 - May 2027)
           - docker_image: ubuntu:jammy
@@ -160,21 +146,6 @@ jobs:
       - run: .github/workflows/check-ros2-distribution.sh "${{ matrix.ros_distribution }}"
         if: matrix.ros_version == 2
 
-  test_multiple_ros_installations:
-    name: "ROS and ROS 2 Binary Install Test Suite (Linux only)"
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.7.0
-        with:
-          node-version: "16.x"
-      - run: .github/workflows/build-and-test.sh
-      - uses: ./ # Uses an action in the root directory
-        with:
-          required-ros-distributions: noetic foxy
-      - run: .github/workflows/check-ros2-distribution.sh foxy
-      - run: .github/workflows/check-ros-distribution.sh noetic
-
   test_repo_with_root_setup_cfg:
     name: "Test with setup.cfg file in root directory (Linux only)"
     runs-on: ubuntu-22.04
@@ -192,7 +163,7 @@ jobs:
     name: "Test on a setup-ros-docker container"
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.7.0
@@ -208,7 +179,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The workflow `test` is iterating on all ROS 2 distributions, on macOS, and Windo
 The workflow `test_docker` is iterating on all ROS and ROS 2 distributions, for all supported Ubuntu distributions, using Docker.
 The test matrix associates each distribution with one Docker image.
 This is required to ensure that the appropriate Ubuntu container is used.
-For example, Melodic requires `bionic`, Humble requires `jammy`, etc.
+For example, Noetic requires `focal`, Humble requires `jammy`, etc.
 
 ```yaml
 jobs:
@@ -195,7 +195,6 @@ jobs:
       matrix:
         os: [macOS-latest, windows-latest]
         ros_distribution: # Only include ROS 2 distributions, as ROS 1 does not support macOS and Windows.
-          - foxy
           - humble
           - iron
     steps:
@@ -213,9 +212,7 @@ jobs:
     strategy:
       matrix:
         ros_distribution:
-          - melodic
           - noetic
-          - foxy
           - humble
           - iron
 
@@ -228,23 +225,10 @@ jobs:
         # https://ros.org/reps/rep-0003.html
         # https://ros.org/reps/rep-2000.html
         include:
-          # Melodic Morenia (May 2018 - May 2023)
-          - docker_image: ubuntu:bionic
-            ros_distribution: melodic
-            # Setting ros_version is helpful to customize the workflow
-            # depending on whether a ROS 1, or ROS 2 is being tested.
-            # See 'if: ros_version ==' below for an example.
-            ros_version: 1
-
           # Noetic Ninjemys (May 2020 - May 2025)
           - docker_image: ubuntu:focal
             ros_distribution: noetic
             ros_version: 1
-
-          # Foxy Fitzroy (June 2020 - May 2023)
-          - docker_image: ubuntu:focal
-            ros_distribution: foxy
-            ros_version: 2
 
           # Humble Hawksbill (May 2022 - May 2027)
           - docker_image: ubuntu:jammy

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -29,10 +29,10 @@ describe("basic workflow tests", () => {
 	});
 });
 
-describe("required-ros-distributions/melodic workflow tests", () => {
+describe("required-ros-distributions/noetic workflow tests", () => {
 	beforeAll(() => {
 		jest.spyOn(actions_exec, "exec").mockImplementation(jest.fn());
-		jest.spyOn(core, "getInput").mockReturnValue("melodic");
+		jest.spyOn(core, "getInput").mockReturnValue("noetic");
 	});
 
 	afterAll(() => {
@@ -54,9 +54,7 @@ describe("required-ros-distributions/melodic workflow tests", () => {
 
 describe("validate distribution test", () => {
 	it("test valid", async () => {
-		await expect(utils.validateDistro(["melodic"])).toBe(true);
 		await expect(utils.validateDistro(["noetic"])).toBe(true);
-		await expect(utils.validateDistro(["foxy"])).toBe(true);
 		await expect(utils.validateDistro(["humble"])).toBe(true);
 		await expect(utils.validateDistro(["iron"])).toBe(true);
 		await expect(utils.validateDistro(["rolling"])).toBe(true);
@@ -75,12 +73,14 @@ describe("validate distribution test", () => {
 		await expect(utils.validateDistro(["jade"])).toBe(false);
 		await expect(utils.validateDistro(["kinetic"])).toBe(false);
 		await expect(utils.validateDistro(["lunar"])).toBe(false);
+		await expect(utils.validateDistro(["melodic"])).toBe(false);
 		//ROS2 End-of-Life
 		await expect(utils.validateDistro(["ardent"])).toBe(false);
 		await expect(utils.validateDistro(["bouncy"])).toBe(false);
 		await expect(utils.validateDistro(["crystal"])).toBe(false);
 		await expect(utils.validateDistro(["dashing"])).toBe(false);
 		await expect(utils.validateDistro(["eloquent"])).toBe(false);
+		await expect(utils.validateDistro(["foxy"])).toBe(false);
 		await expect(utils.validateDistro(["galactic"])).toBe(false);
 		// Does not exist or not all valid
 		await expect(utils.validateDistro(["foxy", "doesntexist"])).toBe(false);

--- a/action.yml
+++ b/action.yml
@@ -26,9 +26,7 @@ inputs:
 
       Allowed ROS distributions
       - "" (no value) - no ROS binary installation
-      - melodic
       - noetic
-      - foxy
       - humble
       - iron
       - rolling

--- a/dist/index.js
+++ b/dist/index.js
@@ -6570,17 +6570,6 @@ const aptDependencies = [
     "libtinyxml2-dev",
 ];
 const distributionSpecificAptDependencies = {
-    bionic: [
-        // OpenSplice
-        "libopensplice69",
-        // python3-rosdep is conflicting with ros-melodic-desktop-full,
-        // and should not be used here. See ros-tooling/setup-ros#74
-        "python-rosdep",
-        // python required for sourcing setup.sh
-        "python",
-        "libc++-dev",
-        "libc++abi-dev",
-    ],
     focal: [
         // python-rosdep does not exist on Focal, so python3-rosdep is used.
         // The issue with ros-melodic-desktop-full is also non-applicable.
@@ -6598,7 +6587,6 @@ const distributionSpecificAptDependencies = {
     ],
 };
 const aptRtiConnextDds = {
-    bionic: "rti-connext-dds-5.3.1",
     focal: "rti-connext-dds-5.3.1",
     jammy: "rti-connext-dds-6.0.1",
 };
@@ -7093,7 +7081,7 @@ WE+F5FaIKwb72PL4rLi4
 -----END PGP PUBLIC KEY BLOCK-----
 `;
 // List of linux distributions that need http://packages.ros.org/ros/ubuntu APT repo
-const distrosRequiringRosUbuntu = ["bionic", "focal"];
+const distrosRequiringRosUbuntu = ["focal"];
 /**
  * Install ROS 2 on a Linux worker.
  */
@@ -7312,8 +7300,7 @@ const chocolatey = __importStar(__nccwpck_require__(855));
 const pip = __importStar(__nccwpck_require__(6744));
 const utils = __importStar(__nccwpck_require__(1314));
 const binaryReleases = {
-    foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20221021/ros2-foxy-20221021-windows-release-amd64.zip",
-    humble: "https://github.com/ros2/ros2/releases/download/release-humble-20230213/ros2-humble-20230127-windows-release-amd64.zip",
+    humble: "https://github.com/ros2/ros2/releases/download/release-humble-20230614/ros2-humble-20230614-windows-release-amd64.zip",
     iron: "https://github.com/ros2/ros2/releases/download/release-iron-20230523/ros2-iron-20230523-windows-release-amd64.zip",
 };
 const pip3Packages = ["lxml", "netifaces"];
@@ -7535,14 +7522,7 @@ function getRequiredRosDistributions() {
 }
 exports.getRequiredRosDistributions = getRequiredRosDistributions;
 //list of valid linux distributions
-const validDistro = [
-    "melodic",
-    "noetic",
-    "foxy",
-    "humble",
-    "iron",
-    "rolling",
-];
+const validDistro = ["noetic", "humble", "iron", "rolling"];
 //Determine whether all inputs name supported ROS distributions.
 function validateDistro(requiredRosDistributionsList) {
     for (const rosDistro of requiredRosDistributionsList) {

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -29,18 +29,6 @@ const aptDependencies: string[] = [
 ];
 
 const distributionSpecificAptDependencies = {
-	bionic: [
-		// OpenSplice
-		"libopensplice69",
-
-		// python3-rosdep is conflicting with ros-melodic-desktop-full,
-		// and should not be used here. See ros-tooling/setup-ros#74
-		"python-rosdep",
-		// python required for sourcing setup.sh
-		"python",
-		"libc++-dev",
-		"libc++abi-dev",
-	],
 	focal: [
 		// python-rosdep does not exist on Focal, so python3-rosdep is used.
 		// The issue with ros-melodic-desktop-full is also non-applicable.
@@ -59,7 +47,6 @@ const distributionSpecificAptDependencies = {
 };
 
 const aptRtiConnextDds = {
-	bionic: "rti-connext-dds-5.3.1",
 	focal: "rti-connext-dds-5.3.1",
 	jammy: "rti-connext-dds-6.0.1",
 };

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -51,7 +51,7 @@ WE+F5FaIKwb72PL4rLi4
 `;
 
 // List of linux distributions that need http://packages.ros.org/ros/ubuntu APT repo
-const distrosRequiringRosUbuntu = ["bionic", "focal"];
+const distrosRequiringRosUbuntu = ["focal"];
 
 /**
  * Install ROS 2 on a Linux worker.

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -7,9 +7,8 @@ import * as pip from "./package_manager/pip";
 import * as utils from "./utils";
 
 const binaryReleases: { [index: string]: string } = {
-	foxy: "https://github.com/ros2/ros2/releases/download/release-foxy-20221021/ros2-foxy-20221021-windows-release-amd64.zip",
 	humble:
-		"https://github.com/ros2/ros2/releases/download/release-humble-20230213/ros2-humble-20230127-windows-release-amd64.zip",
+		"https://github.com/ros2/ros2/releases/download/release-humble-20230614/ros2-humble-20230614-windows-release-amd64.zip",
 	iron: "https://github.com/ros2/ros2/releases/download/release-iron-20230523/ros2-iron-20230523-windows-release-amd64.zip",
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,14 +41,7 @@ export function getRequiredRosDistributions(): string[] {
 }
 
 //list of valid linux distributions
-const validDistro: string[] = [
-	"melodic",
-	"noetic",
-	"foxy",
-	"humble",
-	"iron",
-	"rolling",
-];
+const validDistro: string[] = ["noetic", "humble", "iron", "rolling"];
 
 //Determine whether all inputs name supported ROS distributions.
 export function validateDistro(


### PR DESCRIPTION
* Drop support for Melodic and Foxy, since they are now EOL
* Drop support for Ubuntu Bionic, since there is no longer an active ROS distro for it (used to be Melodic)
* Since there is no longer (and never will be) a common Ubuntu version for a ROS 1 distro and a ROS 2 distro, remove the `test_multiple_ros_installations` CI test job
* Update Windows binaries for Humble
* Update distros in README