### PR TITLE
Add Ubuntu 24.04 Noble and switch Rolling to it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2
@@ -123,7 +124,7 @@ jobs:
             ros_version: 2
 
           # Rolling Ridley (see REP 2002: https://www.ros.org/reps/rep-2002.html)
-          - docker_image: ubuntu:jammy
+          - docker_image: ubuntu:noble
             ros_distribution: rolling
             ros_version: 2
 
@@ -148,7 +149,7 @@ jobs:
 
   test_repo_with_root_setup_cfg:
     name: "Test with setup.cfg file in root directory (Linux only)"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2
@@ -163,7 +164,7 @@ jobs:
     name: "Test on a setup-ros-docker container"
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
+      image: rostooling/setup-ros-docker:ubuntu-noble-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2
@@ -179,7 +180,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,14 +37,16 @@ jobs:
 
   test_environment_linux:
     name: "Check development tools"
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.docker_image }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-20.04
-          - ubuntu-22.04
-          - ubuntu-24.04
+        docker_image:
+          - ubuntu:20.04
+          - ubuntu:22.04
+          - ubuntu:24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2
@@ -149,7 +151,9 @@ jobs:
 
   test_repo_with_root_setup_cfg:
     name: "Test with setup.cfg file in root directory (Linux only)"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2
@@ -175,12 +179,14 @@ jobs:
 
   test_install_connext:
     name: "Test with RTI Connext DDS"
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.docker_image }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-24.04
+        docker_image:
+          - ubuntu:24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ jobs:
   build_docker:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:jammy
+      image: ubuntu:noble
     steps:
       - name: Setup ROS
         uses: ros-tooling/setup-ros@v0.7
@@ -185,7 +185,7 @@ The workflow `test` is iterating on all ROS 2 distributions, on macOS, and Windo
 The workflow `test_docker` is iterating on all ROS and ROS 2 distributions, for all supported Ubuntu distributions, using Docker.
 The test matrix associates each distribution with one Docker image.
 This is required to ensure that the appropriate Ubuntu container is used.
-For example, Noetic requires `focal`, Humble requires `jammy`, etc.
+For example, Noetic requires `focal`, Humble requires `jammy`, Jazzy requires `noble`, etc.
 
 ```yaml
 jobs:
@@ -241,7 +241,7 @@ jobs:
             ros_version: 2
 
           # Rolling Ridley (No End-Of-Life)
-          - docker_image: ubuntu:jammy
+          - docker_image: ubuntu:noble
             ros_distribution: rolling
             ros_version: 2
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6650,9 +6650,35 @@ const distributionSpecificAptDependencies = {
         // libc++-dev and libc++abi-dev installs intentionally removed because:
         // https://github.com/ros-tooling/setup-ros/issues/506
     ],
+    noble: [
+        // Basic development packages (from ROS 2 source/development setup instructions)
+        // ros-dev-tools includes many packages that we needed to include manually in Focal & older
+        "python3-flake8-docstrings",
+        "python3-pip",
+        "python3-pytest-cov",
+        "python3-flake8-blind-except",
+        "python3-flake8-builtins",
+        "python3-flake8-class-newline",
+        "python3-flake8-comprehensions",
+        "python3-flake8-deprecated",
+        "python3-flake8-import-order",
+        "python3-flake8-quotes",
+        "python3-pytest-repeat",
+        "python3-pytest-rerunfailures",
+        "ros-dev-tools",
+        // Additional colcon packages (not included in ros-dev-tools)
+        "python3-colcon-coveragepy-result",
+        "python3-colcon-lcov-result",
+        "python3-colcon-meson",
+        "python3-colcon-mixin",
+        // FastRTPS dependencies
+        "libasio-dev",
+        "libtinyxml2-dev",
+    ],
 };
 const aptRtiConnextDds = {
     jammy: "rti-connext-dds-6.0.1",
+    noble: "rti-connext-dds-6.0.1",
 };
 /**
  * Run apt-get install on list of specified packages.
@@ -7254,9 +7280,11 @@ function runLinux() {
         yield addAptRepoKey();
         const ubuntuCodename = yield utils.determineDistribCodename();
         yield addAptRepo(ubuntuCodename, use_ros2_testing);
-        // Temporary fix to avoid error mount: /var/lib/grub/esp: special device (...) does not exist.
-        yield utils.exec("sudo", ["apt-mark", "hold", "grub-efi-amd64-signed"]);
-        yield utils.exec("sudo", ["apt-get", "upgrade", "-y"]);
+        if ("noble" !== ubuntuCodename) {
+            // Temporary fix to avoid error mount: /var/lib/grub/esp: special device (...) does not exist.
+            yield utils.exec("sudo", ["apt-mark", "hold", "grub-efi-amd64-signed"]);
+            yield utils.exec("sudo", ["apt-get", "upgrade", "-y"]);
+        }
         // Install development-related packages and some common dependencies
         yield apt.installAptDependencies(installConnext);
         // We don't use pip here to install dependencies for ROS 2

--- a/dist/index.js
+++ b/dist/index.js
@@ -6653,16 +6653,11 @@ const distributionSpecificAptDependencies = {
     noble: [
         // Basic development packages (from ROS 2 source/development setup instructions)
         // ros-dev-tools includes many packages that we needed to include manually in Focal & older
-        "python3-flake8-docstrings",
         "python3-pip",
         "python3-pytest-cov",
         "python3-flake8-blind-except",
-        "python3-flake8-builtins",
         "python3-flake8-class-newline",
-        "python3-flake8-comprehensions",
         "python3-flake8-deprecated",
-        "python3-flake8-import-order",
-        "python3-flake8-quotes",
         "python3-pytest-repeat",
         "python3-pytest-rerunfailures",
         "ros-dev-tools",
@@ -6671,9 +6666,6 @@ const distributionSpecificAptDependencies = {
         "python3-colcon-lcov-result",
         "python3-colcon-meson",
         "python3-colcon-mixin",
-        // FastRTPS dependencies
-        "libasio-dev",
-        "libtinyxml2-dev",
     ],
 };
 const aptRtiConnextDds = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6666,6 +6666,8 @@ const distributionSpecificAptDependencies = {
         "python3-colcon-lcov-result",
         "python3-colcon-meson",
         "python3-colcon-mixin",
+        // Others
+        "python3-importlib-metadata",
     ],
 };
 const aptRtiConnextDds = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7281,6 +7281,16 @@ function runLinux() {
         }
         // Install development-related packages and some common dependencies
         yield apt.installAptDependencies(installConnext);
+        // Workaround for Noble: we need a newer version of python3-flake8
+        if ("noble" == ubuntuCodename) {
+            yield utils.exec("sudo", [
+                "bash",
+                "-c",
+                `echo "deb http://archive.ubuntu.com/ubuntu/ ${ubuntuCodename}-proposed restricted main multiverse universe" >> /etc/apt/sources.list.d/ubuntu-${ubuntuCodename}-proposed.list`,
+            ]);
+            yield utils.exec("sudo", ["apt-get", "update"]);
+            yield apt.runAptGetInstall([`python3-flake8/${ubuntuCodename}-proposed`]);
+        }
         // We don't use pip here to install dependencies for ROS 2
         if (ubuntuCodename === ros1UbuntuVersion) {
             /* pip3 dependencies need to be installed after the APT ones, as pip3

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -62,10 +62,36 @@ const distributionSpecificAptDependencies = {
 		// libc++-dev and libc++abi-dev installs intentionally removed because:
 		// https://github.com/ros-tooling/setup-ros/issues/506
 	],
+	noble: [
+		// Basic development packages (from ROS 2 source/development setup instructions)
+		// ros-dev-tools includes many packages that we needed to include manually in Focal & older
+		"python3-flake8-docstrings",
+		"python3-pip",
+		"python3-pytest-cov",
+		"python3-flake8-blind-except",
+		"python3-flake8-builtins",
+		"python3-flake8-class-newline",
+		"python3-flake8-comprehensions",
+		"python3-flake8-deprecated",
+		"python3-flake8-import-order",
+		"python3-flake8-quotes",
+		"python3-pytest-repeat",
+		"python3-pytest-rerunfailures",
+		"ros-dev-tools",
+		// Additional colcon packages (not included in ros-dev-tools)
+		"python3-colcon-coveragepy-result",
+		"python3-colcon-lcov-result",
+		"python3-colcon-meson",
+		"python3-colcon-mixin",
+		// FastRTPS dependencies
+		"libasio-dev",
+		"libtinyxml2-dev",
+	],
 };
 
 const aptRtiConnextDds = {
 	jammy: "rti-connext-dds-6.0.1",
+	noble: "rti-connext-dds-6.0.1",
 };
 
 /**

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -78,6 +78,8 @@ const distributionSpecificAptDependencies = {
 		"python3-colcon-lcov-result",
 		"python3-colcon-meson",
 		"python3-colcon-mixin",
+		// Others
+		"python3-importlib-metadata",
 	],
 };
 

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -65,16 +65,11 @@ const distributionSpecificAptDependencies = {
 	noble: [
 		// Basic development packages (from ROS 2 source/development setup instructions)
 		// ros-dev-tools includes many packages that we needed to include manually in Focal & older
-		"python3-flake8-docstrings",
 		"python3-pip",
 		"python3-pytest-cov",
 		"python3-flake8-blind-except",
-		"python3-flake8-builtins",
 		"python3-flake8-class-newline",
-		"python3-flake8-comprehensions",
 		"python3-flake8-deprecated",
-		"python3-flake8-import-order",
-		"python3-flake8-quotes",
 		"python3-pytest-repeat",
 		"python3-pytest-rerunfailures",
 		"ros-dev-tools",
@@ -83,9 +78,6 @@ const distributionSpecificAptDependencies = {
 		"python3-colcon-lcov-result",
 		"python3-colcon-meson",
 		"python3-colcon-mixin",
-		// FastRTPS dependencies
-		"libasio-dev",
-		"libtinyxml2-dev",
 	],
 };
 

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -166,9 +166,11 @@ export async function runLinux(): Promise<void> {
 	const ubuntuCodename = await utils.determineDistribCodename();
 	await addAptRepo(ubuntuCodename, use_ros2_testing);
 
-	// Temporary fix to avoid error mount: /var/lib/grub/esp: special device (...) does not exist.
-	await utils.exec("sudo", ["apt-mark", "hold", "grub-efi-amd64-signed"]);
-	await utils.exec("sudo", ["apt-get", "upgrade", "-y"]);
+	if ("noble" !== ubuntuCodename) {
+		// Temporary fix to avoid error mount: /var/lib/grub/esp: special device (...) does not exist.
+		await utils.exec("sudo", ["apt-mark", "hold", "grub-efi-amd64-signed"]);
+		await utils.exec("sudo", ["apt-get", "upgrade", "-y"]);
+	}
 
 	// Install development-related packages and some common dependencies
 	await apt.installAptDependencies(installConnext);

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -175,6 +175,17 @@ export async function runLinux(): Promise<void> {
 	// Install development-related packages and some common dependencies
 	await apt.installAptDependencies(installConnext);
 
+	// Workaround for Noble: we need a newer version of python3-flake8
+	if ("noble" == ubuntuCodename) {
+		await utils.exec("sudo", [
+			"bash",
+			"-c",
+			`echo "deb http://archive.ubuntu.com/ubuntu/ ${ubuntuCodename}-proposed restricted main multiverse universe" >> /etc/apt/sources.list.d/ubuntu-${ubuntuCodename}-proposed.list`,
+		]);
+		await utils.exec("sudo", ["apt-get", "update"]);
+		await apt.runAptGetInstall([`python3-flake8/${ubuntuCodename}-proposed`]);
+	}
+
 	// We don't use pip here to install dependencies for ROS 2
 	if (ubuntuCodename === ros1UbuntuVersion) {
 		/* pip3 dependencies need to be installed after the APT ones, as pip3


### PR DESCRIPTION
Relates to https://github.com/ros-tooling/action-ros-ci/pull/842

See also https://github.com/ros-tooling/setup-ros-docker/pull/69 (required for the `Test on a setup-ros-docker container` CI job)

Closes #659

Rolling is moving to Ubuntu 24.04 Noble: https://discourse.ros.org/t/preparing-ros-2-rolling-for-the-transition-to-ubuntu-24-04/35673.

Note: the `ubuntu-24.04`GitHub runner is not available yet: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners. I changed the workflow configs to use a Ubuntu Noble Docker image on top of `ubuntu-latest`. We could just keep this and not have to remove the workaround + bring it back for Ubuntu 26.04.

I also removed some `apt` from the list for Noble, since we can just rely on `rosdep`:

1. Some flake8 plugins, see: https://github.com/ros2/ros2_documentation/pull/3945
2. `libtinyxml2-dev` installed for `tinyxml2_vendor`