### PR TITLE
Remove python3-flake8 workaround for Noble

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7281,16 +7281,6 @@ function runLinux() {
         }
         // Install development-related packages and some common dependencies
         yield apt.installAptDependencies(installConnext);
-        // Workaround for Noble: we need a newer version of python3-flake8
-        if ("noble" == ubuntuCodename) {
-            yield utils.exec("sudo", [
-                "bash",
-                "-c",
-                `echo "deb http://archive.ubuntu.com/ubuntu/ ${ubuntuCodename}-proposed restricted main multiverse universe" >> /etc/apt/sources.list.d/ubuntu-${ubuntuCodename}-proposed.list`,
-            ]);
-            yield utils.exec("sudo", ["apt-get", "update"]);
-            yield apt.runAptGetInstall([`python3-flake8/${ubuntuCodename}-proposed`]);
-        }
         // We don't use pip here to install dependencies for ROS 2
         if (ubuntuCodename === ros1UbuntuVersion) {
             /* pip3 dependencies need to be installed after the APT ones, as pip3

--- a/src/setup-ros-linux.ts
+++ b/src/setup-ros-linux.ts
@@ -175,17 +175,6 @@ export async function runLinux(): Promise<void> {
 	// Install development-related packages and some common dependencies
 	await apt.installAptDependencies(installConnext);
 
-	// Workaround for Noble: we need a newer version of python3-flake8
-	if ("noble" == ubuntuCodename) {
-		await utils.exec("sudo", [
-			"bash",
-			"-c",
-			`echo "deb http://archive.ubuntu.com/ubuntu/ ${ubuntuCodename}-proposed restricted main multiverse universe" >> /etc/apt/sources.list.d/ubuntu-${ubuntuCodename}-proposed.list`,
-		]);
-		await utils.exec("sudo", ["apt-get", "update"]);
-		await apt.runAptGetInstall([`python3-flake8/${ubuntuCodename}-proposed`]);
-	}
-
 	// We don't use pip here to install dependencies for ROS 2
 	if (ubuntuCodename === ros1UbuntuVersion) {
 		/* pip3 dependencies need to be installed after the APT ones, as pip3


### PR DESCRIPTION
Follow-up to #658. We needed `python3-flake8` version 7.0.0 and had to install it from the `noble-proposed` apt repo. Now that it is available from the main repo, we can remove this workaround: https://packages.ubuntu.com/noble/python3-flake8