### PR TITLE
Add support for Jazzy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
           - noetic
           - humble
           - iron
+          - jazzy
           - rolling
 
         # Define the Docker image(s) associated with each ROS distribution.
@@ -125,6 +126,11 @@ jobs:
             ros_distribution: iron
             ros_version: 2
 
+          # Jazzy Jalisco (May 2024 - November 2029)
+          - docker_image: ubuntu:noble
+            ros_distribution: jazzy
+            ros_version: 2
+
           # Rolling Ridley (see REP 2002: https://www.ros.org/reps/rep-2002.html)
           - docker_image: ubuntu:noble
             ros_distribution: rolling
@@ -143,6 +149,8 @@ jobs:
       - uses: ./ # Uses an action in the root directory
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
+          # Use ros2-testing repo for Jazzy before it's officially release
+          use-ros2-testing: ${{ matrix.ros_distribution == 'jazzy' }}
       - run: .github/workflows/check-environment.sh
       - run: .github/workflows/check-ros-distribution.sh "${{ matrix.ros_distribution }}"
         if: matrix.ros_version == 1

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -57,6 +57,7 @@ describe("validate distribution test", () => {
 		await expect(utils.validateDistro(["noetic"])).toBe(true);
 		await expect(utils.validateDistro(["humble"])).toBe(true);
 		await expect(utils.validateDistro(["iron"])).toBe(true);
+		await expect(utils.validateDistro(["jazzy"])).toBe(true);
 		await expect(utils.validateDistro(["rolling"])).toBe(true);
 	});
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,7 @@ inputs:
       - noetic
       - humble
       - iron
+      - jazzy
       - rolling
 
       Multiple values can be passed using a whitespace delimited list

--- a/dist/index.js
+++ b/dist/index.js
@@ -7643,7 +7643,7 @@ function getRequiredRosDistributions() {
 }
 exports.getRequiredRosDistributions = getRequiredRosDistributions;
 //list of valid linux distributions
-const validDistro = ["noetic", "humble", "iron", "rolling"];
+const validDistro = ["noetic", "humble", "iron", "jazzy", "rolling"];
 //Determine whether all inputs name supported ROS distributions.
 function validateDistro(requiredRosDistributionsList) {
     for (const rosDistro of requiredRosDistributionsList) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ export function getRequiredRosDistributions(): string[] {
 }
 
 //list of valid linux distributions
-const validDistro: string[] = ["noetic", "humble", "iron", "rolling"];
+const validDistro: string[] = ["noetic", "humble", "iron", "jazzy", "rolling"];
 
 //Determine whether all inputs name supported ROS distributions.
 export function validateDistro(


### PR DESCRIPTION
We need to use the testing apt repo to get Jazzy binaries for tests before Jazzy is officially released. See: https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debians.html#enable-required-repositories. Once Jazzy has been released, we can revert this.

Users will need to use `use-ros2-testing: true` for Jazzy.

I won't mention Jazzy in the README until it's officially been released

Relates to https://github.com/ros-tooling/action-ros-ci/pull/863
Relates to https://github.com/ros-tooling/setup-ros-docker/pull/71