### PR TITLE
fix: modify macos ci

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7033,6 +7033,13 @@ const pip3Packages = [
     "setuptools<60.0",
     "wheel",
 ];
+const pip3ConfigCommandLine = [
+    "pip3",
+    "config",
+    "set",
+    "global.break-system-packages",
+    "true",
+];
 const pip3CommandLine = ["pip3", "install", "--upgrade"];
 /**
  * Run Python3 pip install on a list of specified packages.
@@ -7049,9 +7056,11 @@ function runPython3PipInstall(packages, run_with_sudo = true) {
             cwd: path.sep,
         };
         if (run_with_sudo) {
+            utils.exec("sudo", pip3ConfigCommandLine);
             return utils.exec("sudo", pip3CommandLine.concat(packages), options);
         }
         else {
+            utils.exec(pip3ConfigCommandLine[0], pip3ConfigCommandLine.splice(1));
             return utils.exec(args[0], args.splice(1), options);
         }
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -7030,7 +7030,7 @@ const pip3Packages = [
     "pytest-repeat",
     "pytest-rerunfailures",
     "pytest-runner",
-    "setuptools<60.0",
+    "setuptools",
     "wheel",
 ];
 const pip3ConfigCommandLine = [

--- a/dist/index.js
+++ b/dist/index.js
@@ -7056,11 +7056,11 @@ function runPython3PipInstall(packages, run_with_sudo = true) {
             cwd: path.sep,
         };
         if (run_with_sudo) {
-            utils.exec("sudo", pip3ConfigCommandLine);
+            yield utils.exec("sudo", pip3ConfigCommandLine);
             return utils.exec("sudo", pip3CommandLine.concat(packages), options);
         }
         else {
-            utils.exec(pip3ConfigCommandLine[0], pip3ConfigCommandLine.splice(1));
+            yield utils.exec(pip3ConfigCommandLine[0], pip3ConfigCommandLine.splice(1));
             return utils.exec(args[0], args.splice(1), options);
         }
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -6752,7 +6752,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.installBrewDependencies = exports.runBrew = void 0;
+exports.setupPython = exports.installBrewDependencies = exports.runBrew = void 0;
 const utils = __importStar(__nccwpck_require__(1314));
 const brewDependencies = [
     "asio",
@@ -6801,6 +6801,33 @@ function installBrewDependencies() {
     });
 }
 exports.installBrewDependencies = installBrewDependencies;
+/**
+ * Set python path to pin specific python.
+ *
+ * @returns Promise<number> exit code
+ */
+function setupPython() {
+    return __awaiter(this, void 0, void 0, function* () {
+        yield utils.exec("find", [
+            "/usr/local/bin",
+            "-lname",
+            "'*/Library/Frameworks/Python.framework/*'",
+            "-delete",
+        ]);
+        yield utils.exec("sudo", [
+            "rm",
+            "-rf",
+            "/Library/Frameworks/Python.framework/",
+        ]);
+        yield utils.exec("brew", ["unlink", "python"]);
+        return utils.exec("ln", [
+            "-s",
+            "/opt/homebrew/bin/pip3.10",
+            "/opt/homebrew/bin/pip3",
+        ]);
+    });
+}
+exports.setupPython = setupPython;
 
 
 /***/ }),
@@ -7356,6 +7383,7 @@ const pip = __importStar(__nccwpck_require__(6744));
 function runOsX() {
     return __awaiter(this, void 0, void 0, function* () {
         yield brew.installBrewDependencies();
+        yield brew.setupPython();
         yield utils.exec("sudo", [
             "bash",
             "-c",

--- a/dist/index.js
+++ b/dist/index.js
@@ -7030,7 +7030,7 @@ const pip3Packages = [
     "pytest-repeat",
     "pytest-rerunfailures",
     "pytest-runner",
-    "setuptools",
+    "setuptools<60.0",
     "wheel",
 ];
 const pip3ConfigCommandLine = [

--- a/src/package_manager/brew.ts
+++ b/src/package_manager/brew.ts
@@ -43,3 +43,28 @@ export async function runBrew(packages: string[]): Promise<number> {
 export async function installBrewDependencies(): Promise<number> {
 	return runBrew(brewDependencies);
 }
+
+/**
+ * Set python path to pin specific python.
+ *
+ * @returns Promise<number> exit code
+ */
+export async function setupPython(): Promise<number> {
+	await utils.exec("find", [
+		"/usr/local/bin",
+		"-lname",
+		"'*/Library/Frameworks/Python.framework/*'",
+		"-delete",
+	]);
+	await utils.exec("sudo", [
+		"rm",
+		"-rf",
+		"/Library/Frameworks/Python.framework/",
+	]);
+	await utils.exec("brew", ["unlink", "python"]);
+	return utils.exec("ln", [
+		"-s",
+		"/opt/homebrew/bin/pip3.10",
+		"/opt/homebrew/bin/pip3",
+	]);
+}

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -57,7 +57,7 @@ const pip3Packages: string[] = [
 	"pytest-repeat",
 	"pytest-rerunfailures",
 	"pytest-runner",
-	"setuptools<60.0",
+	"setuptools",
 	"wheel",
 ];
 

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -90,7 +90,7 @@ export async function runPython3PipInstall(
 		await utils.exec("sudo", pip3ConfigCommandLine);
 		return utils.exec("sudo", pip3CommandLine.concat(packages), options);
 	} else {
-		utils.exec(pip3ConfigCommandLine[0], pip3ConfigCommandLine.splice(1));
+		await utils.exec(pip3ConfigCommandLine[0], pip3ConfigCommandLine.splice(1));
 		return utils.exec(args[0], args.splice(1), options);
 	}
 }

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -61,6 +61,13 @@ const pip3Packages: string[] = [
 	"wheel",
 ];
 
+const pip3ConfigCommandLine: string[] = [
+	"pip3",
+	"config",
+	"set",
+	"global.break-system-packages",
+	"true",
+];
 const pip3CommandLine: string[] = ["pip3", "install", "--upgrade"];
 
 /**
@@ -80,8 +87,10 @@ export async function runPython3PipInstall(
 		cwd: path.sep,
 	};
 	if (run_with_sudo) {
+		utils.exec("sudo", pip3ConfigCommandLine);
 		return utils.exec("sudo", pip3CommandLine.concat(packages), options);
 	} else {
+		utils.exec(pip3ConfigCommandLine[0], pip3ConfigCommandLine.splice(1));
 		return utils.exec(args[0], args.splice(1), options);
 	}
 }

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -57,7 +57,7 @@ const pip3Packages: string[] = [
 	"pytest-repeat",
 	"pytest-rerunfailures",
 	"pytest-runner",
-	"setuptools",
+	"setuptools<60.0",
 	"wheel",
 ];
 

--- a/src/package_manager/pip.ts
+++ b/src/package_manager/pip.ts
@@ -87,7 +87,7 @@ export async function runPython3PipInstall(
 		cwd: path.sep,
 	};
 	if (run_with_sudo) {
-		utils.exec("sudo", pip3ConfigCommandLine);
+		await utils.exec("sudo", pip3ConfigCommandLine);
 		return utils.exec("sudo", pip3CommandLine.concat(packages), options);
 	} else {
 		utils.exec(pip3ConfigCommandLine[0], pip3ConfigCommandLine.splice(1));

--- a/src/setup-ros-osx.ts
+++ b/src/setup-ros-osx.ts
@@ -8,6 +8,7 @@ import * as pip from "./package_manager/pip";
  */
 export async function runOsX() {
 	await brew.installBrewDependencies();
+	await brew.setupPython();
 	await utils.exec("sudo", [
 		"bash",
 		"-c",


### PR DESCRIPTION
This PR fixes:

```
- ModuleNotFoundError: No module named 'distutils'
- note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
  hint: See PEP 668 for the detailed specification.
```

It also pins Python to 3.10 as per REP 2000: https://www.ros.org/reps/rep-2000.html#rolling-ridley-june-2020-ongoing

* remove python3.12 installed in github actions runner
* remove python3.12 installed by brew
* link pip3.10 to pip3 because python3.10 installed by brew doesn't have pip3 link