### PR TITLE
Bump Python to 3.8 on Windows

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7467,7 +7467,8 @@ const pip3Packages = ["lxml", "netifaces"];
  */
 function prepareRos2BuildEnvironment() {
     return __awaiter(this, void 0, void 0, function* () {
-        const python_dir = tc.find("Python", "3.7");
+        // Currently targeted Python version for Windows according to REP 2000
+        const python_dir = tc.find("Python", "3.8");
         yield utils.exec(path.join(python_dir, "python"), [
             "-c",
             "import sysconfig; print(sysconfig.get_config_var('BINDIR')); print(sysconfig.get_path('scripts'))",

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -18,7 +18,8 @@ const pip3Packages: string[] = ["lxml", "netifaces"];
  * Install ROS 2 build tools.
  */
 async function prepareRos2BuildEnvironment() {
-	const python_dir = tc.find("Python", "3.7");
+	// Currently targeted Python version for Windows according to REP 2000
+	const python_dir = tc.find("Python", "3.8");
 
 	await utils.exec(
 		path.join(python_dir, "python"),


### PR DESCRIPTION
3.8 is the currently-targeted Python version for Windows on all currently-supported distro according to REP 2000 for:

* Humble: https://www.ros.org/reps/rep-2000.html#humble-hawksbill-may-2022-may-2027
* Iron: https://www.ros.org/reps/rep-2000.html#iron-irwini-may-2023-november-2024
* Jazzy: https://www.ros.org/reps/rep-2000.html#jazzy-jalisco-may-2024-may-2029