### PR TITLE
Explicitly install libclang-rt-dev on Noble

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6668,6 +6668,9 @@ const distributionSpecificAptDependencies = {
         "python3-colcon-mixin",
         // Others
         "python3-importlib-metadata",
+        // Explicitly install clang-rt:
+        // https://github.com/ros-tooling/setup-ros/issues/685
+        "libclang-rt-dev",
     ],
 };
 const aptRtiConnextDds = {

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -80,6 +80,9 @@ const distributionSpecificAptDependencies = {
 		"python3-colcon-mixin",
 		// Others
 		"python3-importlib-metadata",
+		// Explicitly install clang-rt:
+		// https://github.com/ros-tooling/setup-ros/issues/685
+		"libclang-rt-dev",
 	],
 };
 


### PR DESCRIPTION
Fixes #685