### PR TITLE
Adapt husky config to v9

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,0 @@
-# files for tools like prettier and eslint to ignore
-dist
-coverage
-*.md
-*.yml
-*.yaml

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,5 +19,6 @@
 		"sourceType": "module"
 	},
 	"plugins": ["@typescript-eslint"],
-	"rules": {}
+	"rules": {},
+	"ignorePatterns": ["dist", "coverage", "*.md", "*.yml", "*.yaml"]
 }

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,7 @@
 module.exports = {
 	"*": [
-		"eslint --cache --fix --ignore-path .eslintignore",
-		"prettier --write --ignore-path .eslintignore --ignore-unknown",
+		"eslint --cache --fix --config .eslintrc.json",
+		"prettier --write --config .prettierrc --ignore-path .prettierignore --ignore-unknown",
 		// Note: doing the build here ensures we omit unstaged changes
 		() => "npm run build",
 		() => "git add dist/index.js",

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist
+coverage
+*.md
+*.yml
+*.yaml

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -6,7 +6,7 @@ Install [Node.js](https://nodejs.org/en/download/).
 
 We are currently using Node.js v20.
 
-## Install Dependencies
+## Install dependencies
 
 ```sh
 npm install

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "GitHub Action to setup a ROS 2 development environment",
 	"main": "lib/main.js",
 	"scripts": {
-		"prepare": "husky install",
+		"prepare": "husky",
 		"build": "ncc build src/setup-ros.ts -o dist",
 		"fixup": "eslint . --fix",
 		"lint": "eslint .",


### PR DESCRIPTION
It was bumped to v9 as part of #679.

* The proper command is now just `husky`, not `husky install`, see https://github.com/typicode/husky/releases/tag/v9.0.1
* Move `.eslintignore` patterns to `.eslintrc.json`
* Add ignore patterns for prettier to `.prettierignore`