### PR TITLE
Install RTI Connext DDS 7.3.0 on Ubuntu Noble too

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6160,8 +6160,10 @@ const distributionSpecificAptDependencies = {
     ],
 };
 const aptRtiConnextDds = {
-    jammy: "rti-connext-dds-6.0.1",
-    noble: "rti-connext-dds-6.0.1",
+    jammy: ["rti-connext-dds-6.0.1"],
+    // ROS 2 Rolling switched to Connext 7.3.0 before Kilted;
+    // ROS 2 Jazzy still uses Connext 6.0.1
+    noble: ["rti-connext-dds-6.0.1", "rti-connext-dds-7.3.0-ros"],
 };
 /**
  * Run apt-get install on list of specified packages.

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -87,8 +87,10 @@ const distributionSpecificAptDependencies = {
 };
 
 const aptRtiConnextDds = {
-	jammy: "rti-connext-dds-6.0.1",
-	noble: "rti-connext-dds-6.0.1",
+	jammy: ["rti-connext-dds-6.0.1"],
+	// ROS 2 Rolling switched to Connext 7.3.0 before Kilted;
+	// ROS 2 Jazzy still uses Connext 6.0.1
+	noble: ["rti-connext-dds-6.0.1", "rti-connext-dds-7.3.0-ros"],
 };
 
 /**


### PR DESCRIPTION
ROS 2 Rolling switched to version 7.3.0 (before Kilted): https://github.com/ros2/rmw_connextdds/pull/181.

Note that the rosdep key is `rti-connext-dds-7.3.0` but the underlying package (deb) name is `rti-connext-dds-7.3.0-ros`: https://github.com/ros/rosdistro/pull/44918.