### PR TITLE
Rename default branch to main, add mirror workflow for migration

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,7 +3,7 @@ name: Auto merge
 on:
   pull_request:
     branches:
-      master
+      main
   pull_request_review:
     types:
       - submitted

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,15 @@
+---
+
+name: Mirror branch main to master
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  mirror-to-master:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zofrex/mirror-branch@v1
+        with:
+          target-branch: master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - "releases/*"
   schedule:
     # Run the CI automatically twice per day to look for flakyness.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # `setup-ros`
 
 [![GitHub Action Status](https://github.com/ros-tooling/setup-ros/workflows/Test%20setup-ros/badge.svg)](https://github.com/ros-tooling/setup-ros)
-[![codecov](https://codecov.io/gh/ros-tooling/setup-ros/branch/master/graph/badge.svg)](https://codecov.io/gh/ros-tooling/setup-ros)
+[![codecov](https://codecov.io/gh/ros-tooling/setup-ros/branch/main/graph/badge.svg)](https://codecov.io/gh/ros-tooling/setup-ros)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=ros-tooling/setup-ros)](https://dependabot.com)
-[![License](https://img.shields.io/github/license/ros-tooling/setup-ros)](https://github.com/ros-tooling/setup-ros/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/ros-tooling/setup-ros)](https://github.com/ros-tooling/setup-ros/blob/main/LICENSE)
 
 This action sets up a [ROS] and [ROS 2] environment for use in actions.
 
@@ -78,7 +78,7 @@ See [`src/package_manager/*.ts`](./src/package_manager/) for the complete list.
 See [action.yml](action.yml).
 
 `setup-ros` is under active development, and compatibility between releases is not yet guaranteed.
-Please do not use `ros-tooling/setup-ros@master`.
+Please do not use `ros-tooling/setup-ros@main`.
 Instead, pin your workflows to a particular release, e.g.: `ros-tooling/setup-ros@v0.7`.
 
 ### Setting up the worker, and installing the system dependencies


### PR DESCRIPTION
Similar to https://github.com/ros-tooling/action-ros-ci/pull/974

I've already created a `main` branch, made it the default branch, and updated the branch protection rules to use `main`.