### PR TITLE
Remove tinyxml from macOS installations

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6274,7 +6274,6 @@ const brewDependencies = [
     "python@3.10",
     "qt",
     "spdlog",
-    "tinyxml",
     "tinyxml2",
     "wget",
     "lcov",

--- a/src/package_manager/brew.ts
+++ b/src/package_manager/brew.ts
@@ -19,7 +19,6 @@ const brewDependencies: string[] = [
 	"python@3.10",
 	"qt",
 	"spdlog",
-	"tinyxml",
 	"tinyxml2",
 	"wget",
 	"lcov",


### PR DESCRIPTION
Fixes #820

tinyxml is no longer available from brew: https://formulae.brew.sh/formula/tinyxml

It's no longer needed starting from ROS 2 Jazzy:

* https://github.com/ros2/ros2/issues/987
* https://github.com/ros2/ros2_documentation/pull/4093

We're still supporting Humble, which still depends on tinyxml. Since it's no longer available from brew, I can't (easily) do anything about it.