### PR TITLE
Bump all Windows binary releases to latest

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7309,10 +7309,10 @@ const chocolatey = __importStar(__nccwpck_require__(855));
 const pip = __importStar(__nccwpck_require__(744));
 const utils = __importStar(__nccwpck_require__(314));
 const binaryReleases = {
-    humble: "https://github.com/ros2/ros2/releases/download/release-humble-20230614/ros2-humble-20230614-windows-release-amd64.zip",
-    iron: "https://github.com/ros2/ros2/releases/download/release-iron-20230523/ros2-iron-20230523-windows-release-amd64.zip",
-    jazzy: "https://github.com/ros2/ros2/releases/download/release-jazzy-20240705/ros2-jazzy-20240705-windows-release-amd64.zip",
-    kilted: "https://github.com/ros2/ros2/releases/download/release-kilted-beta-20250430/ros2-kilted-beta-20250430-windows-release-amd64.zip",
+    humble: "https://github.com/ros2/ros2/releases/download/humble-20250331/ros2-humble-20250331-windows-release-amd64.zip",
+    iron: "https://github.com/ros2/ros2/releases/download/release-iron-20241204/ros2-iron-20241204-windows-release-amd64.zip",
+    jazzy: "https://github.com/ros2/ros2/releases/download/release-jazzy-20250430/ros2-jazzy-20250407-windows-release-amd64.zip",
+    kilted: "https://github.com/ros2/ros2/releases/download/release-kilted-20250523/ros2-kilted-20250523-windows-release-amd64.zip",
 };
 const pip3Packages = ["lxml", "netifaces"];
 /**

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -8,12 +8,12 @@ import * as utils from "./utils";
 
 const binaryReleases: { [index: string]: string } = {
 	humble:
-		"https://github.com/ros2/ros2/releases/download/release-humble-20230614/ros2-humble-20230614-windows-release-amd64.zip",
-	iron: "https://github.com/ros2/ros2/releases/download/release-iron-20230523/ros2-iron-20230523-windows-release-amd64.zip",
+		"https://github.com/ros2/ros2/releases/download/humble-20250331/ros2-humble-20250331-windows-release-amd64.zip",
+	iron: "https://github.com/ros2/ros2/releases/download/release-iron-20241204/ros2-iron-20241204-windows-release-amd64.zip",
 	jazzy:
-		"https://github.com/ros2/ros2/releases/download/release-jazzy-20240705/ros2-jazzy-20240705-windows-release-amd64.zip",
+		"https://github.com/ros2/ros2/releases/download/release-jazzy-20250430/ros2-jazzy-20250407-windows-release-amd64.zip",
 	kilted:
-		"https://github.com/ros2/ros2/releases/download/release-kilted-beta-20250430/ros2-kilted-beta-20250430-windows-release-amd64.zip",
+		"https://github.com/ros2/ros2/releases/download/release-kilted-20250523/ros2-kilted-20250523-windows-release-amd64.zip",
 };
 
 const pip3Packages: string[] = ["lxml", "netifaces"];


### PR DESCRIPTION
This patch pumps the following ROS2 Windows releases to latest one:

- humble
- iron
- jazzy
- kilted

Signed-off-by: Minggang Wang <minggangw@gmail.com>