### PR TITLE
Add Ubuntu 26.04 Resolute and switch Rolling to it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
           - ubuntu:20.04
           - ubuntu:22.04
           - ubuntu:24.04
+          - ubuntu:26.04
           - almalinux:8
           - almalinux:9
     steps:
@@ -148,7 +149,7 @@ jobs:
             ros_version: 2
 
           # Rolling Ridley (see REP 2002: https://www.ros.org/reps/rep-2002.html)
-          - docker_image: ubuntu:noble
+          - docker_image: ubuntu:resolute
             ros_distribution: rolling
             ros_version: 2
 
@@ -179,7 +180,7 @@ jobs:
     name: "Test with setup.cfg file in root directory (Linux only)"
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:24.04
+      image: ubuntu:26.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
@@ -212,7 +213,7 @@ jobs:
       fail-fast: false
       matrix:
         docker_image:
-          - ubuntu:24.04
+          - ubuntu:26.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ jobs:
   build_docker:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:noble
+      image: ubuntu:resolute
     steps:
       - name: Setup ROS
         uses: ros-tooling/setup-ros@v0.7
@@ -129,12 +129,12 @@ One or more ROS distributions can be installed simultaneously by passing multipl
 build_docker:
   runs-on: ubuntu-latest
   container:
-    image: ubuntu:noble
+    image: ubuntu:resolute
   steps:
     - uses: ros-tooling/setup-ros@v0.7
       with:
-        required-ros-distributions: jazzy rolling
-    - run: "source /opt/ros/jazzy/setup.bash && ros2 run --help"
+        required-ros-distributions: lyrical rolling
+    - run: "source /opt/ros/lyrical/setup.bash && ros2 run --help"
     - run: "source /opt/ros/rolling/setup.bash && ros2 run --help"
 ```
 
@@ -184,7 +184,7 @@ The workflow `test` is iterating on all ROS 2 distributions, on macOS, and Windo
 The workflow `test_docker` is iterating on all ROS and ROS 2 distributions, for all supported Ubuntu distributions, using Docker.
 The test matrix associates each distribution with one Docker image.
 This is required to ensure that the appropriate Ubuntu container is used.
-For example, Noetic requires `focal`, Humble requires `jammy`, Jazzy requires `noble`, etc.
+For example, Noetic requires `focal`, Humble requires `jammy`, Jazzy requires `noble`, Kilted requires `resolute`, etc.
 
 ```yaml
 jobs:
@@ -246,8 +246,13 @@ jobs:
             ros_distribution: jazzy
             ros_version: 2
 
-          # Rolling Ridley (No End-Of-Life)
+          # Kilted Kaiju (May 2025 - December 2026)
           - docker_image: ubuntu:noble
+            ros_distribution: kilted
+            ros_version: 2
+
+          # Rolling Ridley (No End-Of-Life)
+          - docker_image: ubuntu:resolute
             ros_distribution: rolling
             ros_version: 2
     container:

--- a/dist/index.js
+++ b/dist/index.js
@@ -28610,12 +28610,36 @@ const distributionSpecificAptDependencies = {
         // https://github.com/ros-tooling/setup-ros/issues/685
         "libclang-rt-dev",
     ],
+    resolute: [
+        // Basic development packages (from ROS 2 source/development setup instructions)
+        // ros-dev-tools includes many packages that we needed to include manually in Focal & older
+        "python3-pip",
+        "python3-pytest-cov",
+        "python3-flake8-blind-except",
+        "python3-flake8-class-newline",
+        "python3-flake8-deprecated",
+        "python3-pytest-repeat",
+        "python3-pytest-rerunfailures",
+        "ros-dev-tools",
+        // Additional colcon packages (not included in ros-dev-tools)
+        "python3-colcon-coveragepy-result",
+        "python3-colcon-lcov-result",
+        "python3-colcon-meson",
+        "python3-colcon-mixin",
+        // Others
+        "python3-importlib-metadata",
+    ],
 };
 const aptRtiConnextDds = {
     jammy: ["rti-connext-dds-6.0.1"],
-    // ROS 2 Rolling switched to Connext 7.3.0 before Kilted;
-    // ROS 2 Jazzy still uses Connext 6.0.1
-    noble: ["rti-connext-dds-6.0.1", "rti-connext-dds-7.3.0-ros"],
+    // ROS 2 Jazzy still uses Connext 6.0.1.
+    // ROS 2 Rolling switched to Connext 7.3.0 before Kilted and then switched to Connext 7.7.0 before Lyrical.
+    noble: [
+        "rti-connext-dds-6.0.1",
+        "rti-connext-dds-7.3.0-ros",
+        "rti-connext-dds-7.7.0-ros",
+    ],
+    resolute: ["rti-connext-dds-7.7.0-ros"],
 };
 /**
  * Run apt-get install on list of specified packages.
@@ -29642,7 +29666,7 @@ function runLinux() {
         yield configOs();
         const ubuntuCodename = yield utils.determineDistribCodename();
         yield installRosAptSourcePackageIfNeeded(ubuntuCodename, use_ros2_testing);
-        if ("noble" !== ubuntuCodename) {
+        if ("noble" !== ubuntuCodename && "resolute" !== ubuntuCodename) {
             // Temporary fix to avoid error mount: /var/lib/grub/esp: special device (...) does not exist.
             const arch = yield utils.getArch();
             yield utils.exec("sudo", ["apt-mark", "hold", `grub-efi-${arch}-signed`]);

--- a/src/package_manager/apt.ts
+++ b/src/package_manager/apt.ts
@@ -84,13 +84,37 @@ const distributionSpecificAptDependencies = {
 		// https://github.com/ros-tooling/setup-ros/issues/685
 		"libclang-rt-dev",
 	],
+	resolute: [
+		// Basic development packages (from ROS 2 source/development setup instructions)
+		// ros-dev-tools includes many packages that we needed to include manually in Focal & older
+		"python3-pip",
+		"python3-pytest-cov",
+		"python3-flake8-blind-except",
+		"python3-flake8-class-newline",
+		"python3-flake8-deprecated",
+		"python3-pytest-repeat",
+		"python3-pytest-rerunfailures",
+		"ros-dev-tools",
+		// Additional colcon packages (not included in ros-dev-tools)
+		"python3-colcon-coveragepy-result",
+		"python3-colcon-lcov-result",
+		"python3-colcon-meson",
+		"python3-colcon-mixin",
+		// Others
+		"python3-importlib-metadata",
+	],
 };
 
 const aptRtiConnextDds = {
 	jammy: ["rti-connext-dds-6.0.1"],
-	// ROS 2 Rolling switched to Connext 7.3.0 before Kilted;
-	// ROS 2 Jazzy still uses Connext 6.0.1
-	noble: ["rti-connext-dds-6.0.1", "rti-connext-dds-7.3.0-ros"],
+	// ROS 2 Jazzy still uses Connext 6.0.1.
+	// ROS 2 Rolling switched to Connext 7.3.0 before Kilted and then switched to Connext 7.7.0 before Lyrical.
+	noble: [
+		"rti-connext-dds-6.0.1",
+		"rti-connext-dds-7.3.0-ros",
+		"rti-connext-dds-7.7.0-ros",
+	],
+	resolute: ["rti-connext-dds-7.7.0-ros"],
 };
 
 /**

--- a/src/setup-ros-ubuntu.ts
+++ b/src/setup-ros-ubuntu.ts
@@ -150,7 +150,7 @@ export async function runLinux(): Promise<void> {
 	const ubuntuCodename = await utils.determineDistribCodename();
 	await installRosAptSourcePackageIfNeeded(ubuntuCodename, use_ros2_testing);
 
-	if ("noble" !== ubuntuCodename) {
+	if ("noble" !== ubuntuCodename && "resolute" !== ubuntuCodename) {
 		// Temporary fix to avoid error mount: /var/lib/grub/esp: special device (...) does not exist.
 		const arch = await utils.getArch();
 		await utils.exec("sudo", ["apt-mark", "hold", `grub-efi-${arch}-signed`]);


### PR DESCRIPTION
Closes #877

`rostooling/setup-ros-docker:ubuntu-resolute-latest` doesn't exist yet, so don't switch to it yet.

Similar to the PR that switched to Ubuntu 24.04 two years ago: #658