### PR TITLE
Add support for Lyrical

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
           - ubuntu:26.04
           - almalinux:8
           - almalinux:9
+          - almalinux:10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
@@ -81,6 +82,8 @@ jobs:
           - jazzy
           # Kilted Kaiju (May 2025 - November 2026)
           - kilted
+          # Lyrical Luth (May 2026 - May 2031)
+          - lyrical
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
@@ -148,12 +151,21 @@ jobs:
             ros_distribution: kilted
             ros_version: 2
 
+          # Lyrical Luth (May 2026 - May 2031)
+          - docker_image: ubuntu:resolute
+            ros_distribution: lyrical
+            ros_version: 2
+
+          - docker_image: almalinux:10
+            ros_distribution: lyrical
+            ros_version: 2
+
           # Rolling Ridley (see REP 2002: https://www.ros.org/reps/rep-2002.html)
           - docker_image: ubuntu:resolute
             ros_distribution: rolling
             ros_version: 2
 
-          - docker_image: almalinux:9
+          - docker_image: almalinux:10
             ros_distribution: rolling
             ros_version: 2
 

--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -68,6 +68,7 @@ describe("validate distribution test", () => {
 		await expect(utils.validateDistro(["iron"])).toBe(true);
 		await expect(utils.validateDistro(["jazzy"])).toBe(true);
 		await expect(utils.validateDistro(["kilted"])).toBe(true);
+		await expect(utils.validateDistro(["lyrical"])).toBe(true);
 		await expect(utils.validateDistro(["rolling"])).toBe(true);
 	});
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,7 @@ inputs:
       - iron
       - jazzy
       - kilted
+      - lyrical
       - rolling
 
       Multiple values can be passed using a whitespace delimited list

--- a/dist/index.js
+++ b/dist/index.js
@@ -29048,6 +29048,25 @@ const distributionSpecificDnfDependencies = {
         "python3-importlib-metadata",
         "curl-minimal",
     ],
+    10: [
+        // Basic development packages (from ROS 2 source/development setup instructions)
+        // ros-dev-tools includes many packages that we needed to include manually in Focal & older
+        "python3-pip",
+        "python3-pytest-cov",
+        "python3-pytest-repeat",
+        "python3-pytest-rerunfailures",
+        "ros-build-essential",
+        "python3-colcon-common-extensions",
+        "python3-colcon-mixin",
+        "python3-rosdep",
+        "python3-vcstool",
+        // Additional colcon packages (not included in ros-dev-tools)
+        "python3-colcon-coveragepy-result",
+        "python3-colcon-lcov-result",
+        // Others
+        "python3-importlib-metadata",
+        "curl-minimal",
+    ],
 };
 /**
  * Run dnf install on list of specified packages.

--- a/dist/index.js
+++ b/dist/index.js
@@ -29751,6 +29751,7 @@ const binaryReleases = {
     iron: "https://github.com/ros2/ros2/releases/download/release-iron-20241204/ros2-iron-20241204-windows-release-amd64.zip",
     jazzy: "https://github.com/ros2/ros2/releases/download/release-jazzy-20250430/ros2-jazzy-20250407-windows-release-amd64.zip",
     kilted: "https://github.com/ros2/ros2/releases/download/release-kilted-20250523/ros2-kilted-20250523-windows-release-amd64.zip",
+    lyrical: "https://github.com/ros2/ros2/releases/download/release-lyrical-beta-20260430/ros2-lyrical-2026-04-30-windows-AMD64.zip",
 };
 const pip3Packages = ["lxml", "netifaces"];
 /**
@@ -30013,6 +30014,7 @@ const validDistro = [
     "iron",
     "jazzy",
     "kilted",
+    "lyrical",
     "rolling",
 ];
 //Determine whether all inputs name supported ROS distributions.

--- a/src/package_manager/dnf.ts
+++ b/src/package_manager/dnf.ts
@@ -53,6 +53,25 @@ const distributionSpecificDnfDependencies = {
 		"python3-importlib-metadata",
 		"curl-minimal",
 	],
+	10: [
+		// Basic development packages (from ROS 2 source/development setup instructions)
+		// ros-dev-tools includes many packages that we needed to include manually in Focal & older
+		"python3-pip",
+		"python3-pytest-cov",
+		"python3-pytest-repeat",
+		"python3-pytest-rerunfailures",
+		"ros-build-essential",
+		"python3-colcon-common-extensions",
+		"python3-colcon-mixin",
+		"python3-rosdep",
+		"python3-vcstool",
+		// Additional colcon packages (not included in ros-dev-tools)
+		"python3-colcon-coveragepy-result",
+		"python3-colcon-lcov-result",
+		// Others
+		"python3-importlib-metadata",
+		"curl-minimal",
+	],
 };
 
 /**

--- a/src/setup-ros-windows.ts
+++ b/src/setup-ros-windows.ts
@@ -14,6 +14,8 @@ const binaryReleases: { [index: string]: string } = {
 		"https://github.com/ros2/ros2/releases/download/release-jazzy-20250430/ros2-jazzy-20250407-windows-release-amd64.zip",
 	kilted:
 		"https://github.com/ros2/ros2/releases/download/release-kilted-20250523/ros2-kilted-20250523-windows-release-amd64.zip",
+	lyrical:
+		"https://github.com/ros2/ros2/releases/download/release-lyrical-beta-20260430/ros2-lyrical-2026-04-30-windows-AMD64.zip",
 };
 
 const pip3Packages: string[] = ["lxml", "netifaces"];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,6 +47,7 @@ const validDistro: string[] = [
 	"iron",
 	"jazzy",
 	"kilted",
+	"lyrical",
 	"rolling",
 ];
 


### PR DESCRIPTION
Relates to #879

Similar to #804 for Kilted

I set Lyrical to Resolute and RHEL 10 (which I added support for) and also bumped Rolling to RHEL 10. However, I don't think Rolling or Lyrical debs/rpms are available for these yet.