### PR TITLE
Use new Ubuntu Resolute base image in CI and switch to ghcr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
     name: "Test on a setup-ros-docker container"
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-noble-latest
+      image: ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-ubuntu-resolute:latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0


### PR DESCRIPTION
We'll probably drop Docker Hub eventually: https://github.com/ros-tooling/setup-ros-docker/issues/64

so use this image: https://github.com/ros-tooling/setup-ros-docker/pkgs/container/setup-ros-docker%2Fsetup-ros-docker-ubuntu-resolute. It was added in https://github.com/ros-tooling/setup-ros-docker/pull/91