### PR TITLE
Update Node version from 20 to 24 in action.yml

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
       - run: npm install && npm run lint
       - run: npm run build && git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
       - uses: ./ # Uses an action in the root directory
       - run: .github/workflows/check-environment.sh
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
       - uses: ./ # Uses an action in the root directory
       - run: .github/workflows/check-environment.sh
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
       - uses: ./ # Uses an action in the root directory
         with:
@@ -179,7 +179,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
       - uses: ./ # Uses an action in the root directory
         with:
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
       - run: cp .github/workflows/test_setup.cfg setup.cfg
       - uses: ./ # Uses an action in the root directory
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
       - uses: ./
 
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.1.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
       - uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -39,5 +39,5 @@ inputs:
     required: false
     default: ""
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
Fixes #847.

 Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.