### PR TITLE
wait for the "epel-release" installation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29440,7 +29440,7 @@ function configOs() {
  */
 function addDnfRepo(use_ros2_testing) {
     return __awaiter(this, void 0, void 0, function* () {
-        dnf.runDnfInstall(["epel-release"]);
+        yield dnf.runDnfInstall(["epel-release"]);
         yield utils.exec("bash", [
             "-c",
             "sudo dnf install --setopt=install_weak_deps=False --quiet --assumeyes 'dnf-command(config-manager)'",

--- a/dist/index.js
+++ b/dist/index.js
@@ -29061,7 +29061,7 @@ const distributionSpecificDnfDependencies = {
         "python3-rosdep",
         "python3-vcstool",
         // Additional colcon packages (not included in ros-dev-tools)
-        "python3-colcon-coveragepy-result",
+        // "python3-colcon-coveragepy-result",
         "python3-colcon-lcov-result",
         // Others
         "python3-importlib-metadata",

--- a/src/package_manager/dnf.ts
+++ b/src/package_manager/dnf.ts
@@ -66,7 +66,7 @@ const distributionSpecificDnfDependencies = {
 		"python3-rosdep",
 		"python3-vcstool",
 		// Additional colcon packages (not included in ros-dev-tools)
-		"python3-colcon-coveragepy-result",
+		// "python3-colcon-coveragepy-result",
 		"python3-colcon-lcov-result",
 		// Others
 		"python3-importlib-metadata",

--- a/src/setup-ros-rhel.ts
+++ b/src/setup-ros-rhel.ts
@@ -46,7 +46,7 @@ async function configOs(): Promise<void> {
  * Add OSRF repository.
  */
 async function addDnfRepo(use_ros2_testing: boolean): Promise<void> {
-	dnf.runDnfInstall(["epel-release"]);
+	await dnf.runDnfInstall(["epel-release"]);
 
 	await utils.exec("bash", [
 		"-c",


### PR DESCRIPTION
The CI pipeline installs `epel-release` without waiting for this to finish. This causes a race condition.

I had to remove `python3-colcon-coveragepy-result` from the package list for RHEL 10, as it seems this package is not available on EPEL at the moment: https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/Packages/p/.

Fixes https://github.com/ros-tooling/setup-ros/issues/885.