### PR TITLE
add 'python3-colcon-coveragepy-result' for RHEL 10 again

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29061,7 +29061,7 @@ const distributionSpecificDnfDependencies = {
         "python3-rosdep",
         "python3-vcstool",
         // Additional colcon packages (not included in ros-dev-tools)
-        // "python3-colcon-coveragepy-result",
+        "python3-colcon-coveragepy-result",
         "python3-colcon-lcov-result",
         // Others
         "python3-importlib-metadata",

--- a/src/package_manager/dnf.ts
+++ b/src/package_manager/dnf.ts
@@ -66,7 +66,7 @@ const distributionSpecificDnfDependencies = {
 		"python3-rosdep",
 		"python3-vcstool",
 		// Additional colcon packages (not included in ros-dev-tools)
-		// "python3-colcon-coveragepy-result",
+		"python3-colcon-coveragepy-result",
 		"python3-colcon-lcov-result",
 		// Others
 		"python3-importlib-metadata",


### PR DESCRIPTION
Fixes https://github.com/ros-tooling/setup-ros/issues/888.